### PR TITLE
feat: consistently name as "upgrade-all-services"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## upgrade-all-service-instances (cf cli plugin)
+## upgrade-all-services (cf cli plugin)
 
 A CF-CLI plugin for upgrading all service instances in a CF foundation.
 
@@ -20,7 +20,7 @@ cf install-plugin <path_to_plugin_binary>
 ### Usage
 
 ```
-cf upgrade-all-service-instances <broker_name>
+cf upgrade-all-services <broker_name>
 
 Options:
     -batch-size int "number of concurrent upgrades (default 10)"

--- a/internal/command/upgrade_all_test.go
+++ b/internal/command/upgrade_all_test.go
@@ -33,7 +33,7 @@ var _ = Describe("UpgradeAll", func() {
 		It("returns an error", func() {
 			err := command.UpgradeAll(fakeCliConnection, []string{}, fakeLogger)
 
-			Expect(err).To(MatchError(fmt.Errorf("broker name must be specifed\nusage:\ncf upgrade-all-service-instances <broker-name>")))
+			Expect(err).To(MatchError(fmt.Errorf("broker name must be specifed\nusage:\ncf upgrade-all-services <broker-name>")))
 		})
 	})
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-const Usage = "cf upgrade-all-service-instances <broker-name>"
+const Usage = "cf upgrade-all-services <broker-name>"
 
 func ValidateInput(cliConnection plugin.CliConnection, args []string) error {
 	if len(args) == 0 {

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Validate", func() {
 			It("fails to run the upgrade", func() {
 				err := validate.ValidateInput(&fakeCliConnection, nil)
 
-				Expect(err).To(MatchError(fmt.Errorf("broker name must be specifed\nusage:\ncf upgrade-all-service-instances <broker-name>")))
+				Expect(err).To(MatchError(fmt.Errorf("broker name must be specifed\nusage:\ncf upgrade-all-services <broker-name>")))
 			})
 		})
 

--- a/main.go
+++ b/main.go
@@ -12,11 +12,11 @@ import (
 type UpgradePlugin struct{}
 
 func (p *UpgradePlugin) Run(cliConnection plugin.CliConnection, args []string) {
-	if args[0] == "upgrade-all-service-instances" {
+	if args[0] == "upgrade-all-services" {
 		l := log.New(os.Stdout, "", 0)
 		err := command.UpgradeAll(cliConnection, args[1:], l)
 		if err != nil {
-			l.Printf("upgrade-all-service-instances plugin failed: %s", err.Error())
+			l.Printf("upgrade-all-services plugin failed: %s", err.Error())
 			os.Exit(1)
 		}
 	}
@@ -24,7 +24,7 @@ func (p *UpgradePlugin) Run(cliConnection plugin.CliConnection, args []string) {
 
 func (p *UpgradePlugin) GetMetadata() plugin.PluginMetadata {
 	return plugin.PluginMetadata{
-		Name: "UpgradeAllServiceInstances",
+		Name: "UpgradeAllServices",
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 1,
@@ -37,7 +37,7 @@ func (p *UpgradePlugin) GetMetadata() plugin.PluginMetadata {
 		},
 		Commands: []plugin.Command{
 			{
-				Name:     "upgrade-all-service-instances",
+				Name:     "upgrade-all-services",
 				HelpText: "Upgrade all service instances from a broker to the latest available version of their current service plans.",
 				UsageDetails: plugin.Usage{
 					Usage: validate.Usage,

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 function main {
-  testOutput "Building upgrade-all-service-instances plugin"
+  testOutput "Building upgrade-all-services plugin"
 
   SCRIPTS_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
@@ -14,13 +14,13 @@ function main {
       go build -o "$BUILD_DIR/upgrade-all-service-instance-plugin-dev"
   popd
 
-  testOutput "Installing upgrade-all-service-instances plugin"
+  testOutput "Installing upgrade-all-services plugin"
   cf install-plugin "$BUILD_DIR/upgrade-all-service-instance-plugin-dev" -f
 
-  testOutput "Checking upgrade-all-service-instances plugin is usable"
-  cf upgrade-all-service-instances --help
+  testOutput "Checking upgrade-all-services plugin is usable"
+  cf upgrade-all-services --help
 
-  testOutput "Uninstalling upgrade-all-service-instances plugin"
+  testOutput "Uninstalling upgrade-all-services plugin"
   cf uninstall-plugin UpgradeAllServiceInstances
 
   testOutput "Test Success"


### PR DESCRIPTION
This is the prefix of the repo name, so it makes sense for the command
to match this. So the command has been renamed from
"upgrade-all-service-instances" to "upgrade-all-services" which is
consistent with the repo "upgrade-all-services-cli-plugin" and the
built-in CLI command "upgrade-service"

[#182571088](https://www.pivotaltracker.com/story/show/182571088)