### PR TITLE
feat: add HTTP logging via "-loghttp" flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,17 +10,26 @@ import (
 )
 
 const (
-	Usage               = "cf upgrade-all-services <broker-name>"
+	Usage = "cf upgrade-all-services <broker-name>"
+
 	parallelDefault     = 10
 	parallelFlag        = "parallel"
-	parallelDescription = "number of upgrades to run in parallel (defaults to 10)"
+	parallelDescription = "number of upgrades to run in parallel"
+
+	// Ideally we would have used "-v" as the flag as the CF CLI does,
+	// but unfortunately the CF CLI swallows this flag, and it's not
+	// available to plugins
+	httpLoggingDefault     = false
+	httpLoggingFlag        = "loghttp"
+	httpLoggingDescription = "enable HTTP request logging"
 )
 
 func ParseConfig(conn CLIConnection, args []string) (Config, error) {
 	var cfg Config
 
 	flagSet := flag.NewFlagSet("upgrade-all-services", flag.ContinueOnError)
-	flagSet.IntVar(&cfg.ParallelUpgrades, "parallel", parallelDefault, parallelDescription)
+	flagSet.IntVar(&cfg.ParallelUpgrades, parallelFlag, parallelDefault, parallelDescription)
+	flagSet.BoolVar(&cfg.HTTPLogging, httpLoggingFlag, httpLoggingDefault, httpLoggingDescription)
 
 	for _, s := range []func() error{
 		func() error {
@@ -61,6 +70,7 @@ type Config struct {
 	APIToken          string
 	APIEndpoint       string
 	SkipSSLValidation bool
+	HTTPLogging       bool
 	ParallelUpgrades  int
 }
 
@@ -76,7 +86,8 @@ type CLIConnection interface {
 
 func Options() map[string]string {
 	return map[string]string{
-		fmt.Sprintf("-%s", parallelFlag): parallelDescription,
+		fmt.Sprintf("-%s", parallelFlag):    parallelDescription,
+		fmt.Sprintf("-%s", httpLoggingFlag): httpLoggingDescription,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -52,12 +52,11 @@ func upgradeAllServices(cliConnection plugin.CliConnection, args []string) error
 		return err
 	}
 
-	return upgrader.Upgrade(
-		ccapi.NewCCAPI(
-			requester.NewRequester(cfg.APIEndpoint, cfg.APIToken, cfg.SkipSSLValidation),
-		),
-		cfg.BrokerName,
-		cfg.ParallelUpgrades,
-		logger.New(time.Minute),
-	)
+	logr := logger.New(time.Minute)
+	reqr := requester.NewRequester(cfg.APIEndpoint, cfg.APIToken, cfg.SkipSSLValidation)
+	if cfg.HTTPLogging {
+		reqr.Logger = logr
+	}
+
+	return upgrader.Upgrade(ccapi.NewCCAPI(reqr), cfg.BrokerName, cfg.ParallelUpgrades, logr)
 }


### PR DESCRIPTION
A new "-loghttp" flag enables logging of HTTP requests and responses

[#182426367](https://www.pivotaltracker.com/story/show/182426367)