### PR TITLE
fix: argument parsing consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ cf install-plugin <path_to_plugin_binary>
 ### Usage
 
 ```
-cf upgrade-all-services <broker_name>
+cf upgrade-all-services <broker_name> [options]
 
 Options:
     -parallel - number of upgrades to run in parallel (defaults to 10)
+    -loghttp  - log HTTP requests and responses
 ```

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Config", func() {
 
 		When("set", func() {
 			BeforeEach(func() {
-				fakeArgs = append([]string{"-loghttp"}, fakeArgs...)
+				fakeArgs = append(fakeArgs, "-loghttp")
 			})
 
 			It("is true", func() {
@@ -229,7 +229,7 @@ var _ = Describe("Config", func() {
 
 		When("specified", func() {
 			BeforeEach(func() {
-				fakeArgs = append([]string{"-parallel", "42"}, fakeArgs...)
+				fakeArgs = append(fakeArgs, "-parallel", "42")
 			})
 
 			It("gets the value", func() {
@@ -240,7 +240,7 @@ var _ = Describe("Config", func() {
 
 		When("not a number", func() {
 			BeforeEach(func() {
-				fakeArgs = append([]string{"-parallel", "boudica"}, fakeArgs...)
+				fakeArgs = append(fakeArgs, "-parallel", "boudica")
 			})
 
 			It("returns an error", func() {
@@ -250,7 +250,7 @@ var _ = Describe("Config", func() {
 
 		When("too low", func() {
 			BeforeEach(func() {
-				fakeArgs = []string{"-parallel", "0"}
+				fakeArgs = append(fakeArgs, "-parallel", "0")
 			})
 
 			It("returns an error", func() {
@@ -260,7 +260,7 @@ var _ = Describe("Config", func() {
 
 		When("too high", func() {
 			BeforeEach(func() {
-				fakeArgs = []string{"-parallel", "101"}
+				fakeArgs = append(fakeArgs, "-parallel", "101")
 			})
 
 			It("returns an error", func() {
@@ -307,7 +307,7 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(cfgErr).To(MatchError(`too many parameters`))
+				Expect(cfgErr).To(MatchError(`too many parameters, did not parse: invalid-extra-parameter`))
 			})
 		})
 	})


### PR DESCRIPTION
The Go `flag` package that's used to parse command flags will stop at
the first non-flag argument. As the broker name is a mandatory non-flag
argument, it's complex to allow flag arguments to be specified either
before or after the broker name. So we have decided that the broker
name should always come first, followed by optional flags. The
implementation, tests, help text and README have been updated to
consistently follow this pattern.

[#182426367](https://www.pivotaltracker.com/story/show/182426367)