### PR TITLE
fix: handle CF CLI v6 API versions

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Config", func() {
 	})
 
 	Describe("validating API version", func() {
-		When("API version is valid", func() {
+		When("API version is valid v3", func() {
 			BeforeEach(func() {
 				fakeCLIConnection.ApiVersionReturns("3.99.0", nil)
 			})
@@ -72,13 +72,33 @@ var _ = Describe("Config", func() {
 			})
 		})
 
-		When("API version is too low", func() {
+		When("API version is too low v3", func() {
 			BeforeEach(func() {
 				fakeCLIConnection.ApiVersionReturns("3.98.0", nil)
 			})
 
 			It("returns an error", func() {
-				Expect(cfgErr).To(MatchError(`plugin requires minimum API version v3.99, got: "3.98.0"`))
+				Expect(cfgErr).To(MatchError(`plugin requires minimum API version 3.99.0 or 2.164.0, got "3.98.0"`))
+			})
+		})
+
+		When("API version is valid v2", func() {
+			BeforeEach(func() {
+				fakeCLIConnection.ApiVersionReturns("2.164.0", nil)
+			})
+
+			It("succeeds", func() {
+				Expect(cfgErr).NotTo(HaveOccurred())
+			})
+		})
+
+		When("API version is too low v2", func() {
+			BeforeEach(func() {
+				fakeCLIConnection.ApiVersionReturns("2.163.0", nil)
+			})
+
+			It("returns an error", func() {
+				Expect(cfgErr).To(MatchError(`plugin requires minimum API version 3.99.0 or 2.164.0, got "2.163.0"`))
 			})
 		})
 
@@ -88,7 +108,7 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(cfgErr).To(MatchError(`plugin requires API major version v3, got: "4.0.0"`))
+				Expect(cfgErr).To(MatchError(`plugin requires minimum API version 3.99.0 or 2.164.0, got "4.0.0"`))
 			})
 		})
 


### PR DESCRIPTION
There's a bug in CF CLI v6 where the API version is sometimes reported as v3 and sometimes as v2,
depending on whether "cf login" of "cf api" was used. CAPI release 1.109.0 shipped with both
API v3.99 and CF API v2.164, so if we have at least v2.164 then we know that v3.99 is also available

[#182426367](https://www.pivotaltracker.com/story/show/182426367)