### PR TITLE
feat: Include Instance names in logging output

### DIFF
--- a/internal/ccapi/service_instances.go
+++ b/internal/ccapi/service_instances.go
@@ -9,6 +9,7 @@ import (
 
 type ServiceInstance struct {
 	GUID             string `json:"guid"`
+	Name             string `json:"name"`
 	UpgradeAvailable bool   `json:"upgrade_available"`
 	PlanGUID         string `jsonry:"relationships.service_plan.data.guid"`
 	LastOperation    struct {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -45,14 +45,14 @@ func (l *Logger) Printf(format string, a ...any) {
 	l.printf(format, a...)
 }
 
-func (l *Logger) UpgradeStarting(name string, guid string) {
+func (l *Logger) UpgradeStarting(name, guid string) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
 	l.printf("starting to upgrade instance: %q guid: %q", name, guid)
 }
 
-func (l *Logger) UpgradeSucceeded(name string, guid string, duration time.Duration) {
+func (l *Logger) UpgradeSucceeded(name, guid string, duration time.Duration) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -61,7 +61,7 @@ func (l *Logger) UpgradeSucceeded(name string, guid string, duration time.Durati
 	l.printf("finished upgrade of instance: %q guid: %q successfully after %s", name, guid, duration)
 }
 
-func (l *Logger) UpgradeFailed(name string, guid string, duration time.Duration, err error) {
+func (l *Logger) UpgradeFailed(name, guid string, duration time.Duration, err error) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -25,7 +25,7 @@ func New(period time.Duration) *Logger {
 
 type failure struct {
 	name string
-	id   string
+	guid string
 	err  error
 }
 
@@ -67,7 +67,7 @@ func (l *Logger) UpgradeFailed(name, guid string, duration time.Duration, err er
 
 	l.failures = append(l.failures, failure{
 		name: name,
-		id:   guid,
+		guid: guid,
 		err:  err,
 	})
 	l.complete++
@@ -105,7 +105,7 @@ func (l *Logger) FinalTotals() {
 		fmt.Fprintln(tw, "---------------------\t---------------------\t -------")
 
 		for _, failure := range l.failures {
-			fmt.Fprintf(tw, "%s\t %s\t %s\n", failure.name, failure.id, failure.err)
+			fmt.Fprintf(tw, "%s\t %s\t %s\n", failure.name, failure.guid, failure.err)
 		}
 		tw.Flush()
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -42,44 +42,44 @@ var _ = Describe("Logger", func() {
 
 	It("can log the start of an upgrade", func() {
 		result := captureStdout(func() {
-			l.UpgradeStarting("fake-guid")
+			l.UpgradeStarting("my-instance", "fake-guid")
 		})
-		Expect(result).To(MatchRegexp(timestampRegexp + `: starting to upgrade "fake-guid"\n`))
+		Expect(result).To(MatchRegexp(timestampRegexp + `: starting to upgrade instance: "my-instance" guid: "fake-guid"\n`))
 	})
 
 	It("can log the success of an upgrade", func() {
 		result := captureStdout(func() {
-			l.UpgradeSucceeded("fake-guid", time.Minute)
+			l.UpgradeSucceeded("my-instance", "fake-guid", time.Minute)
 		})
-		Expect(result).To(MatchRegexp(timestampRegexp + `: finished upgrade of "fake-guid" successfully after 1m0s\n`))
+		Expect(result).To(MatchRegexp(timestampRegexp + `: finished upgrade of instance: "my-instance" guid: "fake-guid" successfully after 1m0s\n`))
 	})
 
 	It("can log the failure of an upgrade", func() {
 		result := captureStdout(func() {
-			l.UpgradeFailed("fake-guid", time.Minute, fmt.Errorf("boom"))
+			l.UpgradeFailed("my-instance", "fake-guid", time.Minute, fmt.Errorf("boom"))
 		})
-		Expect(result).To(MatchRegexp(timestampRegexp + `: upgrade of "fake-guid" failed after 1m0s: boom\n`))
+		Expect(result).To(MatchRegexp(timestampRegexp + `: upgrade of instance: "my-instance" guid: "fake-guid" failed after 1m0s: boom\n`))
 	})
 
 	It("can log the final totals", func() {
 		l.InitialTotals(10, 5)
-		l.UpgradeFailed("fake-guid-1", time.Minute, fmt.Errorf("boom"))
-		l.UpgradeFailed("fake-guid-2", time.Minute, fmt.Errorf("bang"))
-		l.UpgradeSucceeded("fake-guid-3", time.Minute)
+		l.UpgradeFailed("my-first-instance", "fake-guid-1", time.Minute, fmt.Errorf("boom"))
+		l.UpgradeFailed("my-second-instance", "fake-guid-2", time.Minute, fmt.Errorf("bang"))
+		l.UpgradeSucceeded("my-third-instance", "fake-guid-3", time.Minute)
 
 		result := captureStdout(func() {
 			l.FinalTotals()
 		})
 		Expect(result).To(MatchRegexp(`: successfully upgraded 1 instances\n`))
 		Expect(result).To(MatchRegexp(`: failed to upgrade 2 instances\n`))
-		Expect(result).To(MatchRegexp(`: fake-guid-1\s+| boom\n'`))
-		Expect(result).To(MatchRegexp(`: fake-guid-2\s+| bang\n'`))
+		Expect(result).To(MatchRegexp(`: my-first-instance\s+| fake-guid-1\s+| boom\n'`))
+		Expect(result).To(MatchRegexp(`: my-second-instance\s+| fake-guid-2\s+| bang\n'`))
 	})
 
 	It("logs on a ticker", func() {
 		l.InitialTotals(10, 5)
-		l.UpgradeSucceeded("fake-guid", time.Minute)
-		l.UpgradeSucceeded("fake-guid", time.Minute)
+		l.UpgradeSucceeded("", "fake-guid", time.Minute)
+		l.UpgradeSucceeded("", "fake-guid", time.Minute)
 
 		result := captureStdout(func() {
 			time.Sleep(150 * time.Millisecond)

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -78,8 +78,8 @@ var _ = Describe("Logger", func() {
 
 	It("logs on a ticker", func() {
 		l.InitialTotals(10, 5)
-		l.UpgradeSucceeded("", "fake-guid", time.Minute)
-		l.UpgradeSucceeded("", "fake-guid", time.Minute)
+		l.UpgradeSucceeded("fake-name", "fake-guid", time.Minute)
+		l.UpgradeSucceeded("fake-name", "fake-guid", time.Minute)
 
 		result := captureStdout(func() {
 			time.Sleep(150 * time.Millisecond)

--- a/internal/upgrader/upgrader.go
+++ b/internal/upgrader/upgrader.go
@@ -19,9 +19,9 @@ type CFClient interface {
 //counterfeiter:generate . Logger
 type Logger interface {
 	Printf(format string, a ...any)
-	UpgradeStarting(name string, guid string)
-	UpgradeSucceeded(name string, guid string, duration time.Duration)
-	UpgradeFailed(name string, guid string, duration time.Duration, err error)
+	UpgradeStarting(name, guid string)
+	UpgradeSucceeded(name, guid string, duration time.Duration)
+	UpgradeFailed(name, guid string, duration time.Duration, err error)
 	InitialTotals(totalServiceInstances, totalUpgradableServiceInstances int)
 	FinalTotals()
 }

--- a/internal/upgrader/upgrader_test.go
+++ b/internal/upgrader/upgrader_test.go
@@ -33,11 +33,13 @@ var _ = Describe("Upgrade", func() {
 			MaintenanceInfoVersion: "test-maintenance-info",
 		}
 		fakeInstance1 = ccapi.ServiceInstance{
+			Name:             "fake-instance-name-1",
 			GUID:             "fake-instance-guid-1",
 			PlanGUID:         fakePlanGUID,
 			UpgradeAvailable: true,
 		}
 		fakeInstance2 = ccapi.ServiceInstance{
+			Name:             "fake-instance-name-2",
 			GUID:             "fake-instance-guid-2",
 			PlanGUID:         fakePlanGUID,
 			UpgradeAvailable: true,
@@ -87,8 +89,12 @@ var _ = Describe("Upgrade", func() {
 		Expect(actualUpgradable).To(Equal(2))
 
 		Expect(fakeLog.UpgradeStartingCallCount()).To(Equal(2))
-		Expect(fakeLog.UpgradeStartingArgsForCall(0)).To(Equal("fake-instance-guid-1"))
-		Expect(fakeLog.UpgradeStartingArgsForCall(1)).To(Equal("fake-instance-guid-2"))
+		name1, guid1 := fakeLog.UpgradeStartingArgsForCall(0)
+		Expect(name1).To(Equal("fake-instance-name-1"))
+		Expect(guid1).To(Equal("fake-instance-guid-1"))
+		name2, guid2 := fakeLog.UpgradeStartingArgsForCall(1)
+		Expect(name2).To(Equal("fake-instance-name-2"))
+		Expect(guid2).To(Equal("fake-instance-guid-2"))
 
 		Expect(fakeLog.UpgradeSucceededCallCount()).To(Equal(2))
 		Expect(fakeLog.UpgradeFailedCallCount()).To(Equal(0))
@@ -195,8 +201,12 @@ var _ = Describe("Upgrade", func() {
 			Expect(actualUpgradable).To(Equal(2))
 
 			Expect(fakeLog.UpgradeStartingCallCount()).To(Equal(2))
-			Expect(fakeLog.UpgradeStartingArgsForCall(0)).To(Equal("fake-instance-guid-1"))
-			Expect(fakeLog.UpgradeStartingArgsForCall(1)).To(Equal("fake-instance-guid-2"))
+			name1, guid1 := fakeLog.UpgradeStartingArgsForCall(0)
+			Expect(name1).To(Equal("fake-instance-name-1"))
+			Expect(guid1).To(Equal("fake-instance-guid-1"))
+			name2, guid2 := fakeLog.UpgradeStartingArgsForCall(1)
+			Expect(name2).To(Equal("fake-instance-name-2"))
+			Expect(guid2).To(Equal("fake-instance-guid-2"))
 
 			Expect(fakeLog.UpgradeSucceededCallCount()).To(Equal(1))
 			Expect(fakeLog.UpgradeFailedCallCount()).To(Equal(1))

--- a/internal/upgrader/upgraderfakes/fake_cfclient.go
+++ b/internal/upgrader/upgraderfakes/fake_cfclient.go
@@ -3,7 +3,6 @@ package upgraderfakes
 
 import (
 	"sync"
-
 	"upgrade-all-services-cli-plugin/internal/ccapi"
 	"upgrade-all-services-cli-plugin/internal/upgrader"
 )

--- a/internal/upgrader/upgraderfakes/fake_logger.go
+++ b/internal/upgrader/upgraderfakes/fake_logger.go
@@ -4,7 +4,6 @@ package upgraderfakes
 import (
 	"sync"
 	"time"
-
 	"upgrade-all-services-cli-plugin/internal/upgrader"
 )
 
@@ -25,23 +24,26 @@ type FakeLogger struct {
 		arg1 string
 		arg2 []any
 	}
-	UpgradeFailedStub        func(string, time.Duration, error)
+	UpgradeFailedStub        func(string, string, time.Duration, error)
 	upgradeFailedMutex       sync.RWMutex
 	upgradeFailedArgsForCall []struct {
 		arg1 string
-		arg2 time.Duration
-		arg3 error
+		arg2 string
+		arg3 time.Duration
+		arg4 error
 	}
-	UpgradeStartingStub        func(string)
+	UpgradeStartingStub        func(string, string)
 	upgradeStartingMutex       sync.RWMutex
 	upgradeStartingArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
-	UpgradeSucceededStub        func(string, time.Duration)
+	UpgradeSucceededStub        func(string, string, time.Duration)
 	upgradeSucceededMutex       sync.RWMutex
 	upgradeSucceededArgsForCall []struct {
 		arg1 string
-		arg2 time.Duration
+		arg2 string
+		arg3 time.Duration
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -137,18 +139,19 @@ func (fake *FakeLogger) PrintfArgsForCall(i int) (string, []any) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeLogger) UpgradeFailed(arg1 string, arg2 time.Duration, arg3 error) {
+func (fake *FakeLogger) UpgradeFailed(arg1 string, arg2 string, arg3 time.Duration, arg4 error) {
 	fake.upgradeFailedMutex.Lock()
 	fake.upgradeFailedArgsForCall = append(fake.upgradeFailedArgsForCall, struct {
 		arg1 string
-		arg2 time.Duration
-		arg3 error
-	}{arg1, arg2, arg3})
+		arg2 string
+		arg3 time.Duration
+		arg4 error
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.UpgradeFailedStub
-	fake.recordInvocation("UpgradeFailed", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("UpgradeFailed", []interface{}{arg1, arg2, arg3, arg4})
 	fake.upgradeFailedMutex.Unlock()
 	if stub != nil {
-		fake.UpgradeFailedStub(arg1, arg2, arg3)
+		fake.UpgradeFailedStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -158,29 +161,30 @@ func (fake *FakeLogger) UpgradeFailedCallCount() int {
 	return len(fake.upgradeFailedArgsForCall)
 }
 
-func (fake *FakeLogger) UpgradeFailedCalls(stub func(string, time.Duration, error)) {
+func (fake *FakeLogger) UpgradeFailedCalls(stub func(string, string, time.Duration, error)) {
 	fake.upgradeFailedMutex.Lock()
 	defer fake.upgradeFailedMutex.Unlock()
 	fake.UpgradeFailedStub = stub
 }
 
-func (fake *FakeLogger) UpgradeFailedArgsForCall(i int) (string, time.Duration, error) {
+func (fake *FakeLogger) UpgradeFailedArgsForCall(i int) (string, string, time.Duration, error) {
 	fake.upgradeFailedMutex.RLock()
 	defer fake.upgradeFailedMutex.RUnlock()
 	argsForCall := fake.upgradeFailedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeLogger) UpgradeStarting(arg1 string) {
+func (fake *FakeLogger) UpgradeStarting(arg1 string, arg2 string) {
 	fake.upgradeStartingMutex.Lock()
 	fake.upgradeStartingArgsForCall = append(fake.upgradeStartingArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.UpgradeStartingStub
-	fake.recordInvocation("UpgradeStarting", []interface{}{arg1})
+	fake.recordInvocation("UpgradeStarting", []interface{}{arg1, arg2})
 	fake.upgradeStartingMutex.Unlock()
 	if stub != nil {
-		fake.UpgradeStartingStub(arg1)
+		fake.UpgradeStartingStub(arg1, arg2)
 	}
 }
 
@@ -190,30 +194,31 @@ func (fake *FakeLogger) UpgradeStartingCallCount() int {
 	return len(fake.upgradeStartingArgsForCall)
 }
 
-func (fake *FakeLogger) UpgradeStartingCalls(stub func(string)) {
+func (fake *FakeLogger) UpgradeStartingCalls(stub func(string, string)) {
 	fake.upgradeStartingMutex.Lock()
 	defer fake.upgradeStartingMutex.Unlock()
 	fake.UpgradeStartingStub = stub
 }
 
-func (fake *FakeLogger) UpgradeStartingArgsForCall(i int) string {
+func (fake *FakeLogger) UpgradeStartingArgsForCall(i int) (string, string) {
 	fake.upgradeStartingMutex.RLock()
 	defer fake.upgradeStartingMutex.RUnlock()
 	argsForCall := fake.upgradeStartingArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeLogger) UpgradeSucceeded(arg1 string, arg2 time.Duration) {
+func (fake *FakeLogger) UpgradeSucceeded(arg1 string, arg2 string, arg3 time.Duration) {
 	fake.upgradeSucceededMutex.Lock()
 	fake.upgradeSucceededArgsForCall = append(fake.upgradeSucceededArgsForCall, struct {
 		arg1 string
-		arg2 time.Duration
-	}{arg1, arg2})
+		arg2 string
+		arg3 time.Duration
+	}{arg1, arg2, arg3})
 	stub := fake.UpgradeSucceededStub
-	fake.recordInvocation("UpgradeSucceeded", []interface{}{arg1, arg2})
+	fake.recordInvocation("UpgradeSucceeded", []interface{}{arg1, arg2, arg3})
 	fake.upgradeSucceededMutex.Unlock()
 	if stub != nil {
-		fake.UpgradeSucceededStub(arg1, arg2)
+		fake.UpgradeSucceededStub(arg1, arg2, arg3)
 	}
 }
 
@@ -223,17 +228,17 @@ func (fake *FakeLogger) UpgradeSucceededCallCount() int {
 	return len(fake.upgradeSucceededArgsForCall)
 }
 
-func (fake *FakeLogger) UpgradeSucceededCalls(stub func(string, time.Duration)) {
+func (fake *FakeLogger) UpgradeSucceededCalls(stub func(string, string, time.Duration)) {
 	fake.upgradeSucceededMutex.Lock()
 	defer fake.upgradeSucceededMutex.Unlock()
 	fake.UpgradeSucceededStub = stub
 }
 
-func (fake *FakeLogger) UpgradeSucceededArgsForCall(i int) (string, time.Duration) {
+func (fake *FakeLogger) UpgradeSucceededArgsForCall(i int) (string, string, time.Duration) {
 	fake.upgradeSucceededMutex.RLock()
 	defer fake.upgradeSucceededMutex.RUnlock()
 	argsForCall := fake.upgradeSucceededArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeLogger) Invocations() map[string][][]interface{} {


### PR DESCRIPTION
It is difficult using the CLI commands only to get from a guid to an instance name. This update makes it easy to identify the names of the instances upgraded successfully or failed ones.

[#182560596](https://www.pivotaltracker.com/story/show/182560596)