### PR TITLE
chore: update .gitignore to ignore build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
+upgrade-all-services-cli-plugin
 .idea/*
 dist/*


### PR DESCRIPTION
Ignore the output of "go build"