### PR TITLE
chore: output checksums as sha1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,3 +13,5 @@ archives:
   files:
   - none*
 changelog:
+checksum:
+  algorithm: sha1


### PR DESCRIPTION
SHA1 is the format needed to add new versions to the plugin download
repo, so it makes sense for goreleases to generate the correct format