### PR TITLE
feat: skip upgrade of instance in create failed state

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -35,6 +35,7 @@ type Logger struct {
 	target    int
 	complete  int
 	successes int
+	skipped   int
 	failures  []failure
 }
 
@@ -43,6 +44,14 @@ func (l *Logger) Printf(format string, a ...any) {
 	defer l.lock.Unlock()
 
 	l.printf(format, a...)
+}
+
+func (l *Logger) SkippingInstance(name, guid string, upgradeAvailable bool, lastOperationType, lastOperationState string) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.skipped++
+	l.printf("skipping instance: %q guid: %q Upgrade Available: %v Last Operation: Type: %q State: %q", name, guid, upgradeAvailable, lastOperationType, lastOperationState)
 }
 
 func (l *Logger) UpgradeStarting(name, guid string) {
@@ -93,6 +102,7 @@ func (l *Logger) FinalTotals() {
 
 	l.printf(l.tickerMessage())
 	l.separator()
+	l.printf("skipped %d instances", l.skipped)
 	l.printf("successfully upgraded %d instances", l.successes)
 
 	if len(l.failures) > 0 {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -40,6 +40,13 @@ var _ = Describe("Logger", func() {
 		Expect(result).To(MatchRegexp(`total instances: 1\n.*upgradable instances: 2\n`))
 	})
 
+	It("can log that it is skipping an instance", func() {
+		result := captureStdout(func() {
+			l.SkippingInstance("my-instance", "fake-guid", true, "create", "failed")
+		})
+		Expect(result).To(MatchRegexp(timestampRegexp + `: skipping instance: "my-instance" guid: "fake-guid" Upgrade Available: true Last Operation: Type: "create" State: "failed"\n`))
+	})
+
 	It("can log the start of an upgrade", func() {
 		result := captureStdout(func() {
 			l.UpgradeStarting("my-instance", "fake-guid")
@@ -66,10 +73,12 @@ var _ = Describe("Logger", func() {
 		l.UpgradeFailed("my-first-instance", "fake-guid-1", time.Minute, fmt.Errorf("boom"))
 		l.UpgradeFailed("my-second-instance", "fake-guid-2", time.Minute, fmt.Errorf("bang"))
 		l.UpgradeSucceeded("my-third-instance", "fake-guid-3", time.Minute)
+		l.SkippingInstance("skipped", "skipped-guid", true, "create", "failed")
 
 		result := captureStdout(func() {
 			l.FinalTotals()
 		})
+		Expect(result).To(MatchRegexp(`: skipped 1 instances\n`))
 		Expect(result).To(MatchRegexp(`: successfully upgraded 1 instances\n`))
 		Expect(result).To(MatchRegexp(`: failed to upgrade 2 instances\n`))
 		Expect(result).To(MatchRegexp(`: my-first-instance\s+| fake-guid-1\s+| boom\n'`))

--- a/internal/upgrader/upgraderfakes/fake_logger.go
+++ b/internal/upgrader/upgraderfakes/fake_logger.go
@@ -24,6 +24,15 @@ type FakeLogger struct {
 		arg1 string
 		arg2 []any
 	}
+	SkippingInstanceStub        func(string, string, bool, string, string)
+	skippingInstanceMutex       sync.RWMutex
+	skippingInstanceArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 bool
+		arg4 string
+		arg5 string
+	}
 	UpgradeFailedStub        func(string, string, time.Duration, error)
 	upgradeFailedMutex       sync.RWMutex
 	upgradeFailedArgsForCall []struct {
@@ -139,6 +148,42 @@ func (fake *FakeLogger) PrintfArgsForCall(i int) (string, []any) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
+func (fake *FakeLogger) SkippingInstance(arg1 string, arg2 string, arg3 bool, arg4 string, arg5 string) {
+	fake.skippingInstanceMutex.Lock()
+	fake.skippingInstanceArgsForCall = append(fake.skippingInstanceArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 bool
+		arg4 string
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.SkippingInstanceStub
+	fake.recordInvocation("SkippingInstance", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.skippingInstanceMutex.Unlock()
+	if stub != nil {
+		fake.SkippingInstanceStub(arg1, arg2, arg3, arg4, arg5)
+	}
+}
+
+func (fake *FakeLogger) SkippingInstanceCallCount() int {
+	fake.skippingInstanceMutex.RLock()
+	defer fake.skippingInstanceMutex.RUnlock()
+	return len(fake.skippingInstanceArgsForCall)
+}
+
+func (fake *FakeLogger) SkippingInstanceCalls(stub func(string, string, bool, string, string)) {
+	fake.skippingInstanceMutex.Lock()
+	defer fake.skippingInstanceMutex.Unlock()
+	fake.SkippingInstanceStub = stub
+}
+
+func (fake *FakeLogger) SkippingInstanceArgsForCall(i int) (string, string, bool, string, string) {
+	fake.skippingInstanceMutex.RLock()
+	defer fake.skippingInstanceMutex.RUnlock()
+	argsForCall := fake.skippingInstanceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
 func (fake *FakeLogger) UpgradeFailed(arg1 string, arg2 string, arg3 time.Duration, arg4 error) {
 	fake.upgradeFailedMutex.Lock()
 	fake.upgradeFailedArgsForCall = append(fake.upgradeFailedArgsForCall, struct {
@@ -250,6 +295,8 @@ func (fake *FakeLogger) Invocations() map[string][][]interface{} {
 	defer fake.initialTotalsMutex.RUnlock()
 	fake.printfMutex.RLock()
 	defer fake.printfMutex.RUnlock()
+	fake.skippingInstanceMutex.RLock()
+	defer fake.skippingInstanceMutex.RUnlock()
 	fake.upgradeFailedMutex.RLock()
 	defer fake.upgradeFailedMutex.RUnlock()
 	fake.upgradeStartingMutex.RLock()


### PR DESCRIPTION
When instances have create failed state it doesnt make sense to attempt upgrade as there is no instance to perform an upgrade on. We log a line to reflect we are skipping such instance and the state.

### Checklist:

* [ ] Have you added Release Notes in the docs respositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
