### PR TITLE
fix: log error details when an error happens upgrading an instance

### DIFF
--- a/internal/ccapi/upgrade_instance_test.go
+++ b/internal/ccapi/upgrade_instance_test.go
@@ -142,7 +142,7 @@ var _ = Describe("UpgradeServiceInstance", func() {
 		})
 		It("returns the error", func() {
 			err := fakeCCAPI.UpgradeServiceInstance("test-guid", "test-mi-version")
-			Expect(err).To(MatchError("upgrade request error: http response: 500"))
+			Expect(err).To(MatchError("upgrade request error: http_error: 500 Internal Server Error response_body: "))
 
 			requests := fakeServer.ReceivedRequests()
 			Expect(requests).To(HaveLen(1))


### PR DESCRIPTION
Error messages returned by CAPI were ignored and just the http error status was logged. When the error happend during the actual upgrade execution in the broker this didn't matter as the error would appear in the last operation for that service instance. However when there is an error prior to reaching the broker (e.g. Plan Inaccessible), or prior to an actual upgrade inside the broker, last_operation for the service instance remains unchanged and hence the error message was lost, making troubleshooting impossible through the plugin, and having to restort to the `cf upgrade-service` command to understand the issue.

[#186169043](https://www.pivotaltracker.com/story/show/186169043)

### Checklist:

* [ ] Have you added Release Notes in the docs respositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
