### PR TITLE
chore: refactor main package into separate files

### DIFF
--- a/upgrade_all.go
+++ b/upgrade_all.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"time"
+	"upgrade-all-services-cli-plugin/internal/ccapi"
+	"upgrade-all-services-cli-plugin/internal/config"
+	"upgrade-all-services-cli-plugin/internal/logger"
+	"upgrade-all-services-cli-plugin/internal/requester"
+	"upgrade-all-services-cli-plugin/internal/upgrader"
+
+	"code.cloudfoundry.org/cli/plugin"
+)
+
+// upgradeAllServices is a coordination layer that connects the different pieces of this plugin together,
+// while delegating the actual work to other packages. Principally it:
+// - reads the endpoint and credentials for connecting to CF
+// - reads and parses the command line arguments
+// - requests the start of the upgrade process with the required data
+func upgradeAllServices(cliConnection plugin.CliConnection, args []string) error {
+	cfg, err := config.ParseConfig(cliConnection, args)
+	if err != nil {
+		return err
+	}
+
+	logr := logger.New(time.Minute)
+	reqr := requester.NewRequester(cfg.APIEndpoint, cfg.APIToken, cfg.SkipSSLValidation)
+	if cfg.HTTPLogging {
+		reqr.Logger = logr
+	}
+
+	return upgrader.Upgrade(ccapi.NewCCAPI(reqr), cfg.BrokerName, cfg.ParallelUpgrades, cfg.DryRun, cfg.CheckUpToDate, logr)
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"code.cloudfoundry.org/cli/plugin"
+	"github.com/blang/semver/v4"
+)
+
+// version will be set via -ldflags at build time
+var version = "0.0.0"
+
+func pluginVersion() plugin.VersionType {
+	v := semver.MustParse(version)
+	return plugin.VersionType{
+		Major: int(v.Major),
+		Minor: int(v.Minor),
+		Build: int(v.Patch),
+	}
+}


### PR DESCRIPTION
To make the single responsibility principle clearer, the main package is separated into:
- main.go - the entry point
- version.go - about the version of this plugin
- upgrade_all.go - coordinates the upgrade
