### PR TITLE
chore: refactor requester package into separate files

### DIFF
--- a/internal/requester/errors.go
+++ b/internal/requester/errors.go
@@ -1,0 +1,17 @@
+package requester
+
+import "fmt"
+
+type ccAPIErrors struct {
+	Errors []ccAPIError
+}
+
+type ccAPIError struct {
+	Code   int    `json:"code"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+func (c ccAPIError) String() string {
+	return fmt.Sprintf("capi_error_code: %d capi_error_title: %s capi_error_detail: %s", c.Code, c.Title, c.Detail)
+}

--- a/internal/requester/get.go
+++ b/internal/requester/get.go
@@ -1,0 +1,46 @@
+package requester
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+)
+
+func (r Requester) Get(url string, receiver any) error {
+	if reflect.TypeOf(receiver).Kind() != reflect.Ptr {
+		return fmt.Errorf("receiver must be of type Pointer")
+	}
+
+	url = fmt.Sprintf("%s/%s", r.baseURL, url)
+	r.Logger.Printf("HTTP GET: %s", url)
+
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating HTTP request: %s", err)
+	}
+	request.Header.Set("Authorization", r.token)
+
+	response, err := r.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("http request error: %s", err)
+	}
+	r.Logger.Printf("Response status %s", response.Status)
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("http response: %d", response.StatusCode)
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("unable to read http response body error: %s", err)
+	}
+	r.Logger.Printf("Response body: %s", data)
+	err = json.Unmarshal(data, &receiver)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal response into receiver error: %s", err)
+	}
+
+	return nil
+}

--- a/internal/requester/logger.go
+++ b/internal/requester/logger.go
@@ -1,0 +1,13 @@
+package requester
+
+// Logger is the interface that a logger must implement
+type Logger interface {
+	Printf(string, ...any)
+}
+
+// nullLogger implements the logger interface but does nothing
+type nullLogger struct{}
+
+func (nullLogger) Printf(string, ...any) {
+	// do nothing
+}

--- a/internal/requester/patch.go
+++ b/internal/requester/patch.go
@@ -1,0 +1,55 @@
+package requester
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (r Requester) Patch(url string, data any) error {
+	d, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("error marshaling data: %s", err)
+	}
+
+	url = fmt.Sprintf("%s/%s", r.baseURL, url)
+	r.Logger.Printf("HTTP PATCH: %s", url)
+	r.Logger.Printf("Request body: %s", d)
+
+	request, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
+	if err != nil {
+		return fmt.Errorf("error creating HTTP request: %s", err)
+	}
+	request.Header.Set("Authorization", r.token)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := r.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("http request error: %s", err)
+	}
+	r.Logger.Printf("Response status %s", response.Status)
+
+	if response.StatusCode != http.StatusAccepted {
+		defer response.Body.Close()
+		data, err := io.ReadAll(response.Body)
+		if err != nil {
+			return fmt.Errorf("unable to read http response body error: %s", err)
+		}
+		r.Logger.Printf("Response body: %s", data)
+
+		var receiver ccAPIErrors
+		err = json.Unmarshal(data, &receiver)
+		if err != nil {
+			return fmt.Errorf("http_error: %s response_body: %s", response.Status, string(data))
+		}
+		err = fmt.Errorf("http_error: %s", response.Status)
+		for _, e := range receiver.Errors {
+			err = fmt.Errorf("%w %s", err, e)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/internal/requester/requester.go
+++ b/internal/requester/requester.go
@@ -1,37 +1,16 @@
 package requester
 
 import (
-	"bytes"
 	"crypto/tls"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"reflect"
 	"time"
 )
 
-type Requester struct {
-	APIBaseURL string
-	APIToken   string
-	client     *http.Client
-	Logger     Logger
-}
-
-type CCApiErrors struct {
-	Errors []CCApiError
-}
-type CCApiError struct {
-	Code   int    `json:"code"`
-	Title  string `json:"title"`
-	Detail string `json:"detail"`
-}
-
 func NewRequester(apiBaseURL, apiToken string, insecureSkipVerify bool) Requester {
 	return Requester{
-		APIBaseURL: apiBaseURL,
-		APIToken:   apiToken,
-		Logger:     nullLogger{},
+		baseURL: apiBaseURL,
+		token:   apiToken,
+		Logger:  nullLogger{},
 		client: &http.Client{
 			Timeout: time.Minute,
 			Transport: &http.Transport{
@@ -41,93 +20,9 @@ func NewRequester(apiBaseURL, apiToken string, insecureSkipVerify bool) Requeste
 	}
 }
 
-type Logger interface {
-	Printf(string, ...any)
-}
-
-func (r Requester) Get(url string, receiver any) error {
-	if reflect.TypeOf(receiver).Kind() != reflect.Ptr {
-		return fmt.Errorf("receiver must be of type Pointer")
-	}
-
-	url = fmt.Sprintf("%s/%s", r.APIBaseURL, url)
-	r.Logger.Printf("HTTP GET: %s", url)
-
-	request, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("error creating HTTP request: %s", err)
-	}
-	request.Header.Set("Authorization", r.APIToken)
-
-	response, err := r.client.Do(request)
-	if err != nil {
-		return fmt.Errorf("http request error: %s", err)
-	}
-	r.Logger.Printf("Response status %s", response.Status)
-	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("http response: %d", response.StatusCode)
-	}
-	defer response.Body.Close()
-
-	data, err := io.ReadAll(response.Body)
-	if err != nil {
-		return fmt.Errorf("unable to read http response body error: %s", err)
-	}
-	r.Logger.Printf("Response body: %s", data)
-	err = json.Unmarshal(data, &receiver)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal response into receiver error: %s", err)
-	}
-
-	return nil
-}
-
-func (r Requester) Patch(url string, data any) error {
-	d, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("error marshaling data: %s", err)
-	}
-
-	url = fmt.Sprintf("%s/%s", r.APIBaseURL, url)
-	r.Logger.Printf("HTTP PATCH: %s", url)
-	r.Logger.Printf("Request body: %s", d)
-
-	request, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(d))
-	if err != nil {
-		return fmt.Errorf("error creating HTTP request: %s", err)
-	}
-	request.Header.Set("Authorization", r.APIToken)
-	request.Header.Set("Content-Type", "application/json")
-
-	response, err := r.client.Do(request)
-	if err != nil {
-		return fmt.Errorf("http request error: %s", err)
-	}
-	r.Logger.Printf("Response status %s", response.Status)
-	if response.StatusCode != http.StatusAccepted {
-		defer response.Body.Close()
-		data, err := io.ReadAll(response.Body)
-		if err != nil {
-			return fmt.Errorf("unable to read http response body error: %s", err)
-		}
-		r.Logger.Printf("Response body: %s", data)
-		receiver := CCApiErrors{}
-		err = json.Unmarshal(data, &receiver)
-		if err != nil {
-			return fmt.Errorf("http_error: %s response_body: %s", response.Status, string(data))
-		}
-		err = fmt.Errorf("http_error: %s", response.Status)
-		for i := range receiver.Errors {
-			err = fmt.Errorf("%w capi_error_code: %d capi_error_title: %s capi_error_detail: %s", err, receiver.Errors[i].Code, receiver.Errors[i].Title, receiver.Errors[i].Detail)
-		}
-		return err
-	}
-
-	return nil
-}
-
-type nullLogger struct{}
-
-func (nullLogger) Printf(string, ...any) {
-	// do nothing
+type Requester struct {
+	baseURL string
+	token   string
+	client  *http.Client
+	Logger  Logger
 }

--- a/internal/requester/requester_test.go
+++ b/internal/requester/requester_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 var _ = Describe("Requester", func() {
-
 	var (
 		fakeRequester requester.Requester
 		fakeServer    *ghttp.Server
@@ -28,15 +27,6 @@ var _ = Describe("Requester", func() {
 		fakeRequester = requester.NewRequester(fakeServer.URL(), "fake-token", false)
 	})
 
-	Describe("NewRequester", func() {
-		It("returns a requester with given values", func() {
-			actualRequester := requester.NewRequester("test-url", "fake-token", false)
-
-			Expect(actualRequester.APIBaseURL).To(Equal("test-url"))
-			Expect(actualRequester.APIToken).To(Equal("fake-token"))
-		})
-	})
-
 	Describe("Get", func() {
 		When("request is valid", func() {
 			BeforeEach(func() {
@@ -48,6 +38,7 @@ var _ = Describe("Requester", func() {
 					),
 				)
 			})
+
 			It("succeeds", func() {
 				err := fakeRequester.Get("test-endpoint", &testReceiver)
 
@@ -66,14 +57,10 @@ var _ = Describe("Requester", func() {
 					),
 				)
 			})
+
 			It("returns an error", func() {
 				err := fakeRequester.Get("not-a-real-url", &testReceiver)
 				Expect(err).To(MatchError("http response: 404"))
-			})
-
-			It("errors if receiver is not of type pointer", func() {
-				err := fakeRequester.Get("test-endpoint", testReceiver)
-				Expect(err).To(MatchError("receiver must be of type Pointer"))
 			})
 		})
 
@@ -87,9 +74,17 @@ var _ = Describe("Requester", func() {
 					),
 				)
 			})
+
 			It("returns an error", func() {
 				err := fakeRequester.Get("test-endpoint", &testReceiver)
 				Expect(err).To(MatchError("failed to unmarshal response into receiver error: unexpected end of JSON input"))
+			})
+		})
+
+		When("passed a receiver that is not a pointer", func() {
+			It("returns an error", func() {
+				err := fakeRequester.Get("test-endpoint", testReceiver)
+				Expect(err).To(MatchError("receiver must be of type Pointer"))
 			})
 		})
 	})
@@ -105,9 +100,11 @@ var _ = Describe("Requester", func() {
 					),
 				)
 			})
+
 			It("succeeds", func() {
 				err := fakeRequester.Patch("test-endpoint", `data`)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeServer.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -122,11 +119,13 @@ var _ = Describe("Requester", func() {
 						),
 					)
 				})
+
 				It("returns an error", func() {
 					err := fakeRequester.Patch("test-endpoint", `data`)
 					Expect(err).To(MatchError("http_error: 500 Internal Server Error response_body: Some body"))
 				})
 			})
+
 			When("fails with capi error", func() {
 				BeforeEach(func() {
 					fakeServer.AppendHandlers(
@@ -137,6 +136,7 @@ var _ = Describe("Requester", func() {
 						),
 					)
 				})
+
 				It("returns an error", func() {
 					err := fakeRequester.Patch("test-endpoint", `data`)
 					Expect(err).To(MatchError("http_error: 500 Internal Server Error capi_error_code: 10008 capi_error_title: error title capi_error_detail: error detail"))
@@ -153,6 +153,7 @@ var _ = Describe("Requester", func() {
 						),
 					)
 				})
+
 				It("returns an error", func() {
 					err := fakeRequester.Patch("test-endpoint", `data`)
 					Expect(err.Error()).To(ContainSubstring("http_error: 500 Internal Server Error"))


### PR DESCRIPTION
- to make the single responsibility principle clearer, the package is separated into different files, each with one responsibility
- attributes on the Requester that should be private are made private
- error parsing made tidier using object-orientation
- tests tidied up, and an implementation test (that tested what should be internals, rather than behavior) was removed

[#186464017](https://www.pivotaltracker.com/story/show/186464017)