### PR TITLE
chore: refactor config package into separate files

### DIFF
--- a/internal/config/cli_connection.go
+++ b/internal/config/cli_connection.go
@@ -1,0 +1,14 @@
+package config
+
+// CLIConnection is the interface that the CF Plugin infrastructure must
+// implement in order to work with this plugin.
+//
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+//counterfeiter:generate . CLIConnection
+type CLIConnection interface {
+	IsLoggedIn() (bool, error)
+	AccessToken() (string, error)
+	ApiVersion() (string, error)
+	ApiEndpoint() (string, error)
+	IsSSLDisabled() (bool, error)
+}

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -1,0 +1,23 @@
+package config
+
+// This defines the text for all the flags
+const (
+	parallelDefault     = 10
+	parallelFlag        = "parallel"
+	parallelDescription = "number of upgrades to run in parallel"
+
+	// Ideally we would have used "-v" as the flag as the CF CLI does,
+	// but unfortunately the CF CLI swallows this flag, and the value
+	// is not available to plugins
+	httpLoggingDefault     = false
+	httpLoggingFlag        = "loghttp"
+	httpLoggingDescription = "enable HTTP request logging"
+
+	dryRunDefault     = false
+	dryRunFlag        = "dry-run"
+	dryRunDescription = "print the service instances that would be upgraded"
+
+	checkUpToDateDefault     = false
+	checkUpToDateFlag        = "check-up-to-date"
+	checkUpToDateDescription = "checks and fails if any service instance is not up-to-date - implies a dry-run"
+)

--- a/internal/config/usage.go
+++ b/internal/config/usage.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// Usage is the short usage string
+const Usage = "cf upgrade-all-services <broker-name> [options]"
+
+// UsageOptions documents the available options. It is called by the CF CLI plugin infrastructure.
+func UsageOptions() map[string]string {
+	return map[string]string{
+		parallelFlag:      parallelDescription,
+		httpLoggingFlag:   httpLoggingDescription,
+		dryRunFlag:        dryRunDescription,
+		checkUpToDateFlag: checkUpToDateDescription,
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s\n", Usage)
+}

--- a/internal/config/validations.go
+++ b/internal/config/validations.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/go-version"
+)
+
+// validateLoginStatus checks that the CF CLI is logged in
+func validateLoginStatus(conn CLIConnection) error {
+	loggedIn, err := conn.IsLoggedIn()
+	switch {
+	case err != nil:
+		return fmt.Errorf("error getting login status: %w", err)
+	case !loggedIn:
+		return fmt.Errorf("you must authenticate with the cf cli before running this command")
+	default:
+		return nil
+	}
+}
+
+// validateAPIVersion checks that the CAPI API version is recent enough
+func validateAPIVersion(conn CLIConnection) error {
+	ver, err := conn.ApiVersion()
+	if err != nil {
+		return fmt.Errorf("error retrieving API version: %w", err)
+	}
+
+	var (
+		v3    = version.Must(version.NewVersion("3"))
+		v4    = version.Must(version.NewVersion("4"))
+		v2min = version.Must(version.NewVersion("2.164"))
+		v3min = version.Must(version.NewVersion("3.99"))
+	)
+
+	v, err := version.NewVersion(ver)
+	switch {
+	case err != nil:
+		return fmt.Errorf("error parsing API version: %w", err)
+	case v.GreaterThanOrEqual(v3min) && v.LessThan(v4):
+		return nil
+	case v.GreaterThanOrEqual(v2min) && v.LessThan(v3):
+		// There's a bug in CF CLI v6 where the API version is sometimes reported as v3 and sometimes as v2,
+		// depending on whether "cf login" or "cf api" was used. CAPI release 1.109.0 shipped with both
+		// API v3.99 and CF API v2.164, so if we have at least v2.164 then we know that v3.99 is also available
+		return nil
+	default:
+		return fmt.Errorf("plugin requires minimum API version %s or %s, got %q", v3min.String(), v2min.String(), v.String())
+	}
+}
+
+// validateParallelUpgrades checks that the parallelisation parameter is within bounds
+func validateParallelUpgrades(p int) error {
+	if p <= 0 || p > 100 {
+		printUsage()
+		return fmt.Errorf("number of parallel upgrades must be in the range of 1 to 100")
+	}
+	return nil
+}
+
+// validateBrokerName checks that the specified broker name is viable
+func validateBrokerName(name string) error {
+	if valid := regexp.MustCompile(`^[\w_.-]+$`).MatchString(name); !valid {
+		printUsage()
+		return fmt.Errorf("broker name contains invalid characters")
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func (p *UpgradePlugin) GetMetadata() plugin.PluginMetadata {
 				HelpText: "Upgrade all service instances from a broker to the latest available version of their current service plans.",
 				UsageDetails: plugin.Usage{
 					Usage:   config.Usage,
-					Options: config.Options(),
+					Options: config.UsageOptions(),
 				},
 			},
 		},


### PR DESCRIPTION
To make the single responsibility principle clearer, the package is separated into different files, each with one responsibility

[#186464017](https://www.pivotaltracker.com/story/show/186464017)