### PR TITLE
chore: make proper use of JSONry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test: download lint test-units ## run lint and unit tests
 
 .PHONY: test-units
 test-units:
-	go run github.com/onsi/ginkgo/v2/ginkgo -r
+	go run github.com/onsi/ginkgo/v2/ginkgo -r -p
 
 .PHONY: download
 download: ## download go module dependencies

--- a/internal/ccapi/ccapi_suite_test.go
+++ b/internal/ccapi/ccapi_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCCapi(t *testing.T) {
+func TestCCAPI(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CCAPI Suite")
 }

--- a/internal/ccapi/service_instances.go
+++ b/internal/ccapi/service_instances.go
@@ -3,8 +3,6 @@ package ccapi
 import (
 	"fmt"
 	"strings"
-
-	"code.cloudfoundry.org/jsonry"
 )
 
 type ServiceInstance struct {
@@ -84,14 +82,6 @@ func (c CCAPI) GetServiceInstances(planGUIDs []string) ([]ServiceInstance, error
 	}
 	embedIncludes(si)
 	return si.Instances, nil
-}
-
-func (s *ServiceInstance) UnmarshalJSON(b []byte) error {
-	return jsonry.Unmarshal(b, s)
-}
-
-func (s *serviceInstances) UnmarshalJSON(b []byte) error {
-	return jsonry.Unmarshal(b, s)
 }
 
 func embedIncludes(si serviceInstances) []ServiceInstance {

--- a/internal/ccapi/service_plans.go
+++ b/internal/ccapi/service_plans.go
@@ -2,27 +2,19 @@ package ccapi
 
 import (
 	"fmt"
-
-	"code.cloudfoundry.org/jsonry"
 )
 
-type servicePlans struct {
-	Plans []Plan `json:"resources"`
-}
-
-type Plan struct {
+type ServicePlan struct {
 	GUID                   string `json:"guid"`
 	MaintenanceInfoVersion string `jsonry:"maintenance_info.version"`
 }
 
-func (c CCAPI) GetServicePlans(brokerName string) ([]Plan, error) {
-	var brokerPlans servicePlans
-	if err := c.requester.Get(fmt.Sprintf("v3/service_plans?per_page=5000&service_broker_names=%s", brokerName), &brokerPlans); err != nil {
+func (c CCAPI) GetServicePlans(brokerName string) ([]ServicePlan, error) {
+	var receiver struct {
+		Plans []ServicePlan `json:"resources"`
+	}
+	if err := c.requester.Get(fmt.Sprintf("v3/service_plans?per_page=5000&service_broker_names=%s", brokerName), &receiver); err != nil {
 		return nil, fmt.Errorf("error getting service plans: %s", err)
 	}
-	return brokerPlans.Plans, nil
-}
-
-func (p *Plan) UnmarshalJSON(b []byte) error {
-	return jsonry.Unmarshal(b, p)
+	return receiver.Plans, nil
 }

--- a/internal/ccapi/upgrade_instance.go
+++ b/internal/ccapi/upgrade_instance.go
@@ -6,12 +6,11 @@ import (
 )
 
 func (c CCAPI) UpgradeServiceInstance(guid, miVersion string) error {
-	var body struct {
-		MaintenanceInfo struct {
-			Version string `json:"version"`
-		} `json:"maintenance_info"`
+	body := struct {
+		MaintenanceInfoVersion string `jsonry:"maintenance_info.version"`
+	}{
+		MaintenanceInfoVersion: miVersion,
 	}
-	body.MaintenanceInfo.Version = miVersion
 
 	err := c.requester.Patch(fmt.Sprintf("v3/service_instances/%s", guid), body)
 	if err != nil {

--- a/internal/requester/get.go
+++ b/internal/requester/get.go
@@ -4,20 +4,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 
 	"code.cloudfoundry.org/jsonry"
 )
 
+// Get performs an HTTP GET. It takes a pointer to a struct where the result is stored.
 func (r Requester) Get(url string, receiver any) error {
-	receiverType := reflect.ValueOf(receiver)
-	switch {
-	case receiverType.Kind() != reflect.Ptr:
-		return fmt.Errorf("receiver must be a pointer to a struct, got non-pointer")
-	case receiverType.Elem().Kind() != reflect.Struct:
-		return fmt.Errorf("receiver must be a pointer to a struct, got non-struct")
-	}
-
 	url = fmt.Sprintf("%s/%s", r.baseURL, url)
 	r.Logger.Printf("HTTP GET: %s", url)
 

--- a/internal/requester/patch.go
+++ b/internal/requester/patch.go
@@ -6,10 +6,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
+
+	"code.cloudfoundry.org/jsonry"
 )
 
 func (r Requester) Patch(url string, data any) error {
-	d, err := json.Marshal(data)
+	if reflect.TypeOf(data).Kind() != reflect.Struct {
+		return fmt.Errorf("input body must be a struct")
+	}
+
+	d, err := jsonry.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("error marshaling data: %s", err)
 	}

--- a/internal/requester/patch.go
+++ b/internal/requester/patch.go
@@ -6,16 +6,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 
 	"code.cloudfoundry.org/jsonry"
 )
 
+// Patch performs an HTTP PATCH. It takes a struct as input data.
 func (r Requester) Patch(url string, data any) error {
-	if reflect.TypeOf(data).Kind() != reflect.Struct {
-		return fmt.Errorf("input body must be a struct")
-	}
-
 	d, err := jsonry.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("error marshaling data: %s", err)

--- a/internal/requester/requester_test.go
+++ b/internal/requester/requester_test.go
@@ -1,7 +1,6 @@
 package requester_test
 
 import (
-	"math"
 	"net/http"
 
 	"upgrade-all-services-cli-plugin/internal/requester"
@@ -80,21 +79,6 @@ var _ = Describe("Requester", func() {
 			It("returns an error", func() {
 				err := testRequester.Get("test-endpoint", &testReceiver)
 				Expect(err).To(MatchError("failed to unmarshal response into receiver error: error parsing JSON: EOF"))
-			})
-		})
-
-		When("passed a receiver that is not a pointer", func() {
-			It("returns an error", func() {
-				err := testRequester.Get("test-endpoint", testReceiver)
-				Expect(err).To(MatchError("receiver must be a pointer to a struct, got non-pointer"))
-			})
-		})
-
-		When("passed a receiver that is a pointer to a non-struct", func() {
-			It("returns an error", func() {
-				var s string
-				err := testRequester.Get("test-endpoint", &s)
-				Expect(err).To(MatchError("receiver must be a pointer to a struct, got non-struct"))
 			})
 		})
 	})
@@ -181,11 +165,6 @@ var _ = Describe("Requester", func() {
 					Expect(err.Error()).To(ContainSubstring("capi_error_code: 10009 capi_error_title: other error title capi_error_detail: other error detail"))
 				})
 			})
-		})
-
-		It("errors if body is not a struct", func() {
-			err := testRequester.Patch("test-endpoint", math.Inf(1))
-			Expect(err).To(MatchError("input body must be a struct"))
 		})
 
 		It("errors if body can not be marshalled", func() {

--- a/internal/upgrader/upgrader.go
+++ b/internal/upgrader/upgrader.go
@@ -12,7 +12,7 @@ import (
 //counterfeiter:generate . CFClient
 type CFClient interface {
 	GetServiceInstances([]string) ([]ccapi.ServiceInstance, error)
-	GetServicePlans(string) ([]ccapi.Plan, error)
+	GetServicePlans(string) ([]ccapi.ServicePlan, error)
 	UpgradeServiceInstance(string, string) error
 }
 

--- a/internal/upgrader/upgrader_test.go
+++ b/internal/upgrader/upgrader_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Upgrade", func() {
 
 	var (
 		fakeCFClient                  *upgraderfakes.FakeCFClient
-		fakePlan                      ccapi.Plan
+		fakePlan                      ccapi.ServicePlan
 		fakeInstance1                 ccapi.ServiceInstance
 		fakeInstance2                 ccapi.ServiceInstance
 		fakeInstanceNoUpgrade         ccapi.ServiceInstance
@@ -36,7 +36,7 @@ var _ = Describe("Upgrade", func() {
 	)
 
 	BeforeEach(func() {
-		fakePlan = ccapi.Plan{
+		fakePlan = ccapi.ServicePlan{
 			GUID:                   fakePlanGUID,
 			MaintenanceInfoVersion: "test-maintenance-info",
 		}
@@ -77,7 +77,7 @@ var _ = Describe("Upgrade", func() {
 		fakeServiceInstances = []ccapi.ServiceInstance{fakeInstance1, fakeInstance2, fakeInstanceNoUpgrade, fakeInstanceCreateFailed, fakeInstanceDestroyFailed}
 		fakeServiceInstancesNoUpgrade = []ccapi.ServiceInstance{fakeInstanceNoUpgrade, fakeInstanceCreateFailed}
 		fakeCFClient = &upgraderfakes.FakeCFClient{}
-		fakeCFClient.GetServicePlansReturns([]ccapi.Plan{fakePlan}, nil)
+		fakeCFClient.GetServicePlansReturns([]ccapi.ServicePlan{fakePlan}, nil)
 		fakeCFClient.GetServiceInstancesReturns(fakeServiceInstances, nil)
 
 		fakeLog = &upgraderfakes.FakeLogger{}
@@ -199,7 +199,7 @@ var _ = Describe("Upgrade", func() {
 
 		When("no service plans are available", func() {
 			It("returns error stating no plans available", func() {
-				fakeCFClient.GetServicePlansReturns([]ccapi.Plan{}, nil)
+				fakeCFClient.GetServicePlansReturns([]ccapi.ServicePlan{}, nil)
 
 				err := upgrader.Upgrade(fakeCFClient, fakeBrokerName, 1, false, true, fakeLog)
 				Expect(err).To(MatchError(fmt.Sprintf("no service plans available for broker: %s", fakeBrokerName)))
@@ -227,7 +227,7 @@ var _ = Describe("Upgrade", func() {
 
 	When("no service plans are available", func() {
 		It("returns error stating no plans available", func() {
-			fakeCFClient.GetServicePlansReturns([]ccapi.Plan{}, nil)
+			fakeCFClient.GetServicePlansReturns([]ccapi.ServicePlan{}, nil)
 
 			err := upgrader.Upgrade(fakeCFClient, fakeBrokerName, 1, false, false, fakeLog)
 			Expect(err).To(MatchError(fmt.Sprintf("no service plans available for broker: %s", fakeBrokerName)))

--- a/internal/upgrader/upgraderfakes/fake_cfclient.go
+++ b/internal/upgrader/upgraderfakes/fake_cfclient.go
@@ -21,17 +21,17 @@ type FakeCFClient struct {
 		result1 []ccapi.ServiceInstance
 		result2 error
 	}
-	GetServicePlansStub        func(string) ([]ccapi.Plan, error)
+	GetServicePlansStub        func(string) ([]ccapi.ServicePlan, error)
 	getServicePlansMutex       sync.RWMutex
 	getServicePlansArgsForCall []struct {
 		arg1 string
 	}
 	getServicePlansReturns struct {
-		result1 []ccapi.Plan
+		result1 []ccapi.ServicePlan
 		result2 error
 	}
 	getServicePlansReturnsOnCall map[int]struct {
-		result1 []ccapi.Plan
+		result1 []ccapi.ServicePlan
 		result2 error
 	}
 	UpgradeServiceInstanceStub        func(string, string) error
@@ -119,7 +119,7 @@ func (fake *FakeCFClient) GetServiceInstancesReturnsOnCall(i int, result1 []ccap
 	}{result1, result2}
 }
 
-func (fake *FakeCFClient) GetServicePlans(arg1 string) ([]ccapi.Plan, error) {
+func (fake *FakeCFClient) GetServicePlans(arg1 string) ([]ccapi.ServicePlan, error) {
 	fake.getServicePlansMutex.Lock()
 	ret, specificReturn := fake.getServicePlansReturnsOnCall[len(fake.getServicePlansArgsForCall)]
 	fake.getServicePlansArgsForCall = append(fake.getServicePlansArgsForCall, struct {
@@ -144,7 +144,7 @@ func (fake *FakeCFClient) GetServicePlansCallCount() int {
 	return len(fake.getServicePlansArgsForCall)
 }
 
-func (fake *FakeCFClient) GetServicePlansCalls(stub func(string) ([]ccapi.Plan, error)) {
+func (fake *FakeCFClient) GetServicePlansCalls(stub func(string) ([]ccapi.ServicePlan, error)) {
 	fake.getServicePlansMutex.Lock()
 	defer fake.getServicePlansMutex.Unlock()
 	fake.GetServicePlansStub = stub
@@ -157,28 +157,28 @@ func (fake *FakeCFClient) GetServicePlansArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeCFClient) GetServicePlansReturns(result1 []ccapi.Plan, result2 error) {
+func (fake *FakeCFClient) GetServicePlansReturns(result1 []ccapi.ServicePlan, result2 error) {
 	fake.getServicePlansMutex.Lock()
 	defer fake.getServicePlansMutex.Unlock()
 	fake.GetServicePlansStub = nil
 	fake.getServicePlansReturns = struct {
-		result1 []ccapi.Plan
+		result1 []ccapi.ServicePlan
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeCFClient) GetServicePlansReturnsOnCall(i int, result1 []ccapi.Plan, result2 error) {
+func (fake *FakeCFClient) GetServicePlansReturnsOnCall(i int, result1 []ccapi.ServicePlan, result2 error) {
 	fake.getServicePlansMutex.Lock()
 	defer fake.getServicePlansMutex.Unlock()
 	fake.GetServicePlansStub = nil
 	if fake.getServicePlansReturnsOnCall == nil {
 		fake.getServicePlansReturnsOnCall = make(map[int]struct {
-			result1 []ccapi.Plan
+			result1 []ccapi.ServicePlan
 			result2 error
 		})
 	}
 	fake.getServicePlansReturnsOnCall[i] = struct {
-		result1 []ccapi.Plan
+		result1 []ccapi.ServicePlan
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
JSONry currently requires struct input and output. By enforcing this within this plugin, we can remove lots of marshal/unmarshal interface implementations, simplifying the code.

[#186464017](https://www.pivotaltracker.com/story/show/186464017)