### PR TITLE
test: ccapi.GetServiceInstances() was under-tested

### DIFF
--- a/internal/ccapi/service_instances.go
+++ b/internal/ccapi/service_instances.go
@@ -11,7 +11,7 @@ type ServiceInstance struct {
 	GUID             string `json:"guid"`
 	Name             string `json:"name"`
 	UpgradeAvailable bool   `json:"upgrade_available"`
-	PlanGUID         string `jsonry:"relationships.service_plan.data.guid"`
+	ServicePlanGUID  string `jsonry:"relationships.service_plan.data.guid"`
 	SpaceGUID        string `jsonry:"relationships.space.data.guid"`
 
 	LastOperation LastOperation `json:"last_operation"`
@@ -21,7 +21,7 @@ type ServiceInstance struct {
 
 	// Can't be retrieves from CF API using `fields` query parameter
 	// We populate this field in Upgrade function in internal/upgrader/upgrader.go
-	PlanMaintenanceInfoVersion string
+	PlanMaintenanceInfoVersion string `json:"-"`
 }
 
 type LastOperation struct {
@@ -114,9 +114,9 @@ func embedIncludes(si serviceInstances) []ServiceInstance {
 
 	for i, instance := range si.Instances {
 		emb := EmbeddedInclude{}
-		emb.Plan = plans[instance.PlanGUID]
+		emb.Plan = plans[instance.ServicePlanGUID]
 		emb.Space = spaces[instance.SpaceGUID]
-		emb.ServiceOffering = soffers[plans[instance.PlanGUID].ServiceOfferingGUID]
+		emb.ServiceOffering = soffers[plans[instance.ServicePlanGUID].ServiceOfferingGUID]
 		emb.Organization = orgs[spaces[instance.SpaceGUID].OrganizationGUID]
 
 		si.Instances[i].Included = emb

--- a/internal/ccapi/service_instances_test.go
+++ b/internal/ccapi/service_instances_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 var _ = Describe("GetServiceInstances", func() {
-
 	var (
 		fakeServer *ghttp.Server
 		req        requester.Requester
@@ -29,35 +28,11 @@ var _ = Describe("GetServiceInstances", func() {
 
 	When("service instances exist in the given plans", func() {
 		BeforeEach(func() {
-			responseServiceInstances := `
-			{
-			  "resources": [{
-				"guid": "test-guid",
-				"maintenance_info": {
-				  "version": "1.0.0"
-				},
-				"upgrade_available": true,
-				"last_operation": {
-				  "type": "create",
-				  "state": "succeeded",
-				  "description": "Operation succeeded",
-				  "updated_at": "2020-03-10T15:49:32Z",
-				  "created_at": "2020-03-10T15:49:29Z"
-				},
-				"relationships": {
-				  "service_plan": {
-					"data": {
-					  "guid": "test-plan-guid"
-					}
-				  }
-				}
-			  }]
-			}`
 			fakeServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyHeaderKV("Authorization", "fake-token"),
 					ghttp.VerifyRequest("GET", "/v3/service_instances", ccapi.BuildQueryParams([]string{"test-plan-guid", "another-test-guid"})),
-					ghttp.RespondWith(http.StatusOK, responseServiceInstances),
+					ghttp.RespondWith(http.StatusOK, fakeResponse()),
 				),
 			)
 		})
@@ -67,13 +42,111 @@ var _ = Describe("GetServiceInstances", func() {
 
 			By("checking the valid service instance is returned")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(actualInstances).To(HaveLen(1))
-			Expect(actualInstances[0].GUID).To(Equal("test-guid"))
-			Expect(actualInstances[0].UpgradeAvailable).To(BeTrue())
-			Expect(actualInstances[0].PlanGUID).To(Equal("test-plan-guid"))
-			Expect(actualInstances[0].LastOperation.State).To(Equal("succeeded"))
-			Expect(actualInstances[0].LastOperation.Type).To(Equal("create"))
-			Expect(actualInstances[0].LastOperation.Description).To(Equal("Operation succeeded"))
+
+			Expect(actualInstances).To(ConsistOf(
+				ccapi.ServiceInstance{
+					GUID:             "c5518540-7353-4d66-bae7-e07dfed8dd70",
+					Name:             "fake-service-instance-name-1",
+					UpgradeAvailable: false,
+					ServicePlanGUID:  "72abfc2f-5473-4fda-b895-a59d47b8f001",
+					SpaceGUID:        "dcf1a90a-47ee-4ba2-a369-255aa00c2de0",
+					LastOperation: ccapi.LastOperation{
+						Type:        "create",
+						State:       "succeeded",
+						Description: "Instance provisioning completed",
+					},
+					MaintenanceInfoVersion: "2.10.14-build.3",
+					Included: ccapi.EmbeddedInclude{
+						Plan: ccapi.IncludedPlan{
+							GUID:                "72abfc2f-5473-4fda-b895-a59d47b8f001",
+							Name:                "db-small",
+							ServiceOfferingGUID: "707cff6a-fc54-471a-9594-442c306fb1d0",
+						},
+						ServiceOffering: ccapi.ServiceOffering{
+							GUID: "707cff6a-fc54-471a-9594-442c306fb1d0",
+							Name: "fake-service-offering-name-1",
+						},
+						Space: ccapi.Space{
+							GUID:             "dcf1a90a-47ee-4ba2-a369-255aa00c2de0",
+							Name:             "broker-cf-test",
+							OrganizationGUID: "69086541-1b9d-449d-b8a4-79029b25e74f",
+						},
+						Organization: ccapi.Organization{
+							GUID: "69086541-1b9d-449d-b8a4-79029b25e74f",
+							Name: "pivotal",
+						},
+					},
+					PlanMaintenanceInfoVersion: "", // Not in API response
+				},
+				ccapi.ServiceInstance{
+					GUID:             "3358305d-7402-48b3-80a7-e0148a38675b",
+					Name:             "fake-service-instance-name-2",
+					UpgradeAvailable: false,
+					ServicePlanGUID:  "e55b84e8-b953-4a14-98b2-67bec998a632",
+					SpaceGUID:        "dcf1a90a-47ee-4ba2-a369-255aa00c2de0",
+					LastOperation: ccapi.LastOperation{
+						Type:        "create",
+						State:       "succeeded",
+						Description: "",
+					},
+					MaintenanceInfoVersion: "",
+					Included: ccapi.EmbeddedInclude{
+						Plan: ccapi.IncludedPlan{
+							GUID:                "e55b84e8-b953-4a14-98b2-67bec998a632",
+							Name:                "postgres-db-f1-micro",
+							ServiceOfferingGUID: "8551df49-1fb2-4d12-a009-5307176db52c",
+						},
+						ServiceOffering: ccapi.ServiceOffering{
+							GUID: "8551df49-1fb2-4d12-a009-5307176db52c",
+							Name: "fake-service-offering-name-2",
+						},
+						Space: ccapi.Space{
+							GUID:             "dcf1a90a-47ee-4ba2-a369-255aa00c2de0",
+							Name:             "broker-cf-test",
+							OrganizationGUID: "69086541-1b9d-449d-b8a4-79029b25e74f",
+						},
+						Organization: ccapi.Organization{
+							GUID: "69086541-1b9d-449d-b8a4-79029b25e74f",
+							Name: "pivotal",
+						},
+					},
+					PlanMaintenanceInfoVersion: "", // Not in API response
+				},
+				ccapi.ServiceInstance{
+					GUID:             "5b528bf8-ac0f-4fed-85d0-0fb5f8588968",
+					Name:             "fake-service-instance-name-3",
+					UpgradeAvailable: true,
+					ServicePlanGUID:  "510da794-1e71-4192-bd39-d974de20b7a4",
+					SpaceGUID:        "bbd00d42-8577-11ee-9b75-6feb4799d316",
+					LastOperation: ccapi.LastOperation{
+						Type:        "update",
+						State:       "succeeded",
+						Description: "update succeeded",
+					},
+					MaintenanceInfoVersion: "1.3.9",
+					Included: ccapi.EmbeddedInclude{
+						Plan: ccapi.IncludedPlan{
+							GUID:                "510da794-1e71-4192-bd39-d974de20b7a4",
+							Name:                "small",
+							ServiceOfferingGUID: "ebdddfd4-c95a-4e1a-bdd1-4697ffb57fcd",
+						},
+						ServiceOffering: ccapi.ServiceOffering{
+							GUID: "ebdddfd4-c95a-4e1a-bdd1-4697ffb57fcd",
+							Name: "fake-service-offering-name-3",
+						},
+						Space: ccapi.Space{
+							GUID:             "bbd00d42-8577-11ee-9b75-6feb4799d316",
+							Name:             "broker-csb-test",
+							OrganizationGUID: "529d3532-87a9-11ee-8a24-d354d25d7923",
+						},
+						Organization: ccapi.Organization{
+							GUID: "529d3532-87a9-11ee-8a24-d354d25d7923",
+							Name: "vmware",
+						},
+					},
+					PlanMaintenanceInfoVersion: "", // Not in API response
+				},
+			))
 
 			requests := fakeServer.ReceivedRequests()
 			Expect(requests).To(HaveLen(1))
@@ -111,5 +184,287 @@ var _ = Describe("GetServiceInstances", func() {
 			Expect(err).To(MatchError("error getting service instances: http response: 500"))
 		})
 	})
-
 })
+
+func fakeResponse() string {
+	return `
+{
+  "pagination": {
+    "total_results": 3,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances?fields%5Bservice_plan%5D=name%2Cguid%2Crelationships.service_offering&fields%5Bservice_plan.service_offering%5D=guid%2Cname&fields%5Bspace%5D=name%2Cguid%2Crelationships.organization&fields%5Bspace.organization%5D=name%2Cguid&page=1&per_page=5000&service_plan_guids=72abfc2f-5473-4fda-b895-a59d47b8f001%2Ce55b84e8-b953-4a14-98b2-67bec998a632%2C510da794-1e71-4192-bd39-d974de20b7a4"
+    },
+    "last": {
+      "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances?fields%5Bservice_plan%5D=name%2Cguid%2Crelationships.service_offering&fields%5Bservice_plan.service_offering%5D=guid%2Cname&fields%5Bspace%5D=name%2Cguid%2Crelationships.organization&fields%5Bspace.organization%5D=name%2Cguid&page=1&per_page=5000&service_plan_guids=72abfc2f-5473-4fda-b895-a59d47b8f001%2Ce55b84e8-b953-4a14-98b2-67bec998a632%2C510da794-1e71-4192-bd39-d974de20b7a4"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "c5518540-7353-4d66-bae7-e07dfed8dd70",
+      "created_at": "2023-11-16T23:23:09Z",
+      "updated_at": "2023-11-16T23:23:13Z",
+      "name": "fake-service-instance-name-1",
+      "tags": [],
+      "last_operation": {
+        "type": "create",
+        "state": "succeeded",
+        "description": "Instance provisioning completed",
+        "updated_at": "2023-11-16T23:27:41Z",
+        "created_at": "2023-11-16T23:27:41Z"
+      },
+      "type": "managed",
+      "maintenance_info": {
+        "version": "2.10.14-build.3",
+        "description": "MySQL(\"2.10.14-build.3\") for VMware Tanzu"
+      },
+      "upgrade_available": false,
+      "dashboard_url": null,
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "dcf1a90a-47ee-4ba2-a369-255aa00c2de0"
+          }
+        },
+        "service_plan": {
+          "data": {
+            "guid": "72abfc2f-5473-4fda-b895-a59d47b8f001"
+          }
+        }
+      },
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/c5518540-7353-4d66-bae7-e07dfed8dd70"
+        },
+        "space": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/spaces/dcf1a90a-47ee-4ba2-a369-255aa00c2de0"
+        },
+        "service_credential_bindings": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_credential_bindings?service_instance_guids=c5518540-7353-4d66-bae7-e07dfed8dd70"
+        },
+        "service_route_bindings": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_route_bindings?service_instance_guids=c5518540-7353-4d66-bae7-e07dfed8dd70"
+        },
+        "service_plan": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_plans/72abfc2f-5473-4fda-b895-a59d47b8f001"
+        },
+        "parameters": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/c5518540-7353-4d66-bae7-e07dfed8dd70/parameters"
+        },
+        "shared_spaces": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/c5518540-7353-4d66-bae7-e07dfed8dd70/relationships/shared_spaces"
+        }
+      }
+    },
+    {
+      "guid": "3358305d-7402-48b3-80a7-e0148a38675b",
+      "created_at": "2023-11-17T11:12:37Z",
+      "updated_at": "2023-11-17T11:12:41Z",
+      "name": "fake-service-instance-name-2",
+      "tags": [],
+      "last_operation": {
+        "type": "create",
+        "state": "succeeded",
+        "description": null,
+        "updated_at": "2023-11-17T11:20:24Z",
+        "created_at": "2023-11-17T11:20:24Z"
+      },
+      "type": "managed",
+      "maintenance_info": {},
+      "upgrade_available": false,
+      "dashboard_url": null,
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "dcf1a90a-47ee-4ba2-a369-255aa00c2de0"
+          }
+        },
+        "service_plan": {
+          "data": {
+            "guid": "e55b84e8-b953-4a14-98b2-67bec998a632"
+          }
+        }
+      },
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/3358305d-7402-48b3-80a7-e0148a38675b"
+        },
+        "space": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/spaces/dcf1a90a-47ee-4ba2-a369-255aa00c2de0"
+        },
+        "service_credential_bindings": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_credential_bindings?service_instance_guids=3358305d-7402-48b3-80a7-e0148a38675b"
+        },
+        "service_route_bindings": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_route_bindings?service_instance_guids=3358305d-7402-48b3-80a7-e0148a38675b"
+        },
+        "service_plan": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_plans/e55b84e8-b953-4a14-98b2-67bec998a632"
+        },
+        "parameters": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/3358305d-7402-48b3-80a7-e0148a38675b/parameters"
+        },
+        "shared_spaces": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/3358305d-7402-48b3-80a7-e0148a38675b/relationships/shared_spaces"
+        }
+      }
+    },
+    {
+      "guid": "5b528bf8-ac0f-4fed-85d0-0fb5f8588968",
+      "created_at": "2023-11-17T11:46:11Z",
+      "updated_at": "2023-11-17T11:46:16Z",
+      "name": "fake-service-instance-name-3",
+      "tags": [],
+      "last_operation": {
+        "type": "update",
+        "state": "succeeded",
+        "description": "update succeeded",
+        "updated_at": "2023-11-17T13:56:14Z",
+        "created_at": "2023-11-17T13:56:14Z"
+      },
+      "type": "managed",
+      "maintenance_info": {
+        "version": "1.3.9",
+        "description": "This upgrade provides support for Terraform version: 1.3.9. The upgrade operation will take a while. The instance and all associated bindings will be upgraded."
+      },
+      "upgrade_available": true,
+      "dashboard_url": null,
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "bbd00d42-8577-11ee-9b75-6feb4799d316"
+          }
+        },
+        "service_plan": {
+          "data": {
+            "guid": "510da794-1e71-4192-bd39-d974de20b7a4"
+          }
+        }
+      },
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/5b528bf8-ac0f-4fed-85d0-0fb5f8588968"
+        },
+        "space": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/spaces/dcf1a90a-47ee-4ba2-a369-255aa00c2de0"
+        },
+        "service_credential_bindings": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_credential_bindings?service_instance_guids=5b528bf8-ac0f-4fed-85d0-0fb5f8588968"
+        },
+        "service_route_bindings": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_route_bindings?service_instance_guids=5b528bf8-ac0f-4fed-85d0-0fb5f8588968"
+        },
+        "service_plan": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_plans/510da794-1e71-4192-bd39-d974de20b7a4"
+        },
+        "parameters": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/5b528bf8-ac0f-4fed-85d0-0fb5f8588968/parameters"
+        },
+        "shared_spaces": {
+          "href": "https://api.sys.mycfname.cf-app.com/v3/service_instances/5b528bf8-ac0f-4fed-85d0-0fb5f8588968/relationships/shared_spaces"
+        }
+      }
+    }
+  ],
+  "included": {
+    "spaces": [
+      {
+        "guid": "dcf1a90a-47ee-4ba2-a369-255aa00c2de0",
+        "name": "broker-cf-test",
+        "relationships": {
+          "organization": {
+            "data": {
+              "guid": "69086541-1b9d-449d-b8a4-79029b25e74f"
+            }
+          }
+        }
+      },
+      {
+        "guid": "bbd00d42-8577-11ee-9b75-6feb4799d316",
+        "name": "broker-csb-test",
+        "relationships": {
+          "organization": {
+            "data": {
+              "guid": "529d3532-87a9-11ee-8a24-d354d25d7923"
+            }
+          }
+        }
+      }
+    ],
+    "organizations": [
+      {
+        "name": "pivotal",
+        "guid": "69086541-1b9d-449d-b8a4-79029b25e74f"
+      },
+      {
+        "name": "vmware",
+        "guid": "529d3532-87a9-11ee-8a24-d354d25d7923"
+      }
+    ],
+    "service_plans": [
+      {
+        "guid": "72abfc2f-5473-4fda-b895-a59d47b8f001",
+        "name": "db-small",
+        "relationships": {
+          "service_offering": {
+            "data": {
+              "guid": "707cff6a-fc54-471a-9594-442c306fb1d0"
+            }
+          }
+        }
+      },
+      {
+        "guid": "e55b84e8-b953-4a14-98b2-67bec998a632",
+        "name": "postgres-db-f1-micro",
+        "relationships": {
+          "service_offering": {
+            "data": {
+              "guid": "8551df49-1fb2-4d12-a009-5307176db52c"
+            }
+          }
+        }
+      },
+      {
+        "guid": "510da794-1e71-4192-bd39-d974de20b7a4",
+        "name": "small",
+        "relationships": {
+          "service_offering": {
+            "data": {
+              "guid": "ebdddfd4-c95a-4e1a-bdd1-4697ffb57fcd"
+            }
+          }
+        }
+      }
+    ],
+    "service_offerings": [
+      {
+        "name": "fake-service-offering-name-1",
+        "guid": "707cff6a-fc54-471a-9594-442c306fb1d0"
+      },
+      {
+        "name": "fake-service-offering-name-2",
+        "guid": "8551df49-1fb2-4d12-a009-5307176db52c"
+      },
+      {
+        "name": "fake-service-offering-name-3",
+        "guid": "ebdddfd4-c95a-4e1a-bdd1-4697ffb57fcd"
+      }
+    ]
+  }
+}
+`
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -151,8 +151,8 @@ func indexedInstance(index int, upgradeAvailable bool) ccapi.ServiceInstance {
 		Name: formatValue("my-service-instance", index),
 		GUID: formatValue("my-service-instance-guid", index),
 
-		PlanGUID:  formatValue("fake-plan-guid", index),
-		SpaceGUID: formatValue("fake-space-guid", index),
+		ServicePlanGUID: formatValue("fake-plan-guid", index),
+		SpaceGUID:       formatValue("fake-space-guid", index),
 
 		MaintenanceInfoVersion:     formatValue("fake-version", index),
 		PlanMaintenanceInfoVersion: formatValue("fake-plan-version", index),

--- a/internal/upgrader/upgrader.go
+++ b/internal/upgrader/upgrader.go
@@ -38,7 +38,7 @@ func Upgrade(api CFClient, brokerName string, parallelUpgrades int, dryRun, chec
 
 	// See internal/ccapi/service_instances.go to understand why we are setting this value here
 	for i := range upgradableInstances {
-		upgradableInstances[i].PlanMaintenanceInfoVersion = planVersions[upgradableInstances[i].PlanGUID]
+		upgradableInstances[i].PlanMaintenanceInfoVersion = planVersions[upgradableInstances[i].ServicePlanGUID]
 	}
 
 	switch {
@@ -74,7 +74,7 @@ func performUpgrade(api CFClient, upgradableInstances []ccapi.ServiceInstance, p
 				UpgradeableIndex:       i,
 				ServiceInstanceName:    instance.Name,
 				ServiceInstanceGUID:    instance.GUID,
-				MaintenanceInfoVersion: planVersions[instance.PlanGUID],
+				MaintenanceInfoVersion: planVersions[instance.ServicePlanGUID],
 			}
 		}
 		close(upgradeQueue)

--- a/internal/upgrader/upgrader_test.go
+++ b/internal/upgrader/upgrader_test.go
@@ -43,30 +43,30 @@ var _ = Describe("Upgrade", func() {
 		fakeInstance1 = ccapi.ServiceInstance{
 			Name:             "fake-instance-name-1",
 			GUID:             "fake-instance-guid-1",
-			PlanGUID:         fakePlanGUID,
+			ServicePlanGUID:  fakePlanGUID,
 			UpgradeAvailable: true,
 		}
 		fakeInstance2 = ccapi.ServiceInstance{
 			Name:             "fake-instance-name-2",
 			GUID:             "fake-instance-guid-2",
-			PlanGUID:         fakePlanGUID,
+			ServicePlanGUID:  fakePlanGUID,
 			UpgradeAvailable: true,
 		}
 		fakeInstanceNoUpgrade = ccapi.ServiceInstance{
 			GUID:             "fake-instance-no-upgrade-GUID",
-			PlanGUID:         fakePlanGUID,
+			ServicePlanGUID:  fakePlanGUID,
 			UpgradeAvailable: false,
 		}
 		fakeInstanceCreateFailed = ccapi.ServiceInstance{
 			Name:             "fake-instance-create-failed",
 			GUID:             "fake-instance-create-failed-GUID",
-			PlanGUID:         fakePlanGUID,
+			ServicePlanGUID:  fakePlanGUID,
 			UpgradeAvailable: true,
 		}
 		fakeInstanceDestroyFailed = ccapi.ServiceInstance{
 			Name:             "fake-instance-destroy-failed",
 			GUID:             "fake-instance-destroy-failed-GUID",
-			PlanGUID:         fakePlanGUID,
+			ServicePlanGUID:  fakePlanGUID,
 			UpgradeAvailable: true,
 		}
 


### PR DESCRIPTION
- This method performs quite a lot of data manipulation relating to included fields, but this aspect was untested.
- Also renamed the PlanGUID field to ServicePlanGUID

[#186464017](https://www.pivotaltracker.com/story/show/186464017)