### PR TITLE
fix: exit with error if any instance failed update

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -124,6 +124,12 @@ func (l *Logger) FinalTotals() {
 	logRowFormatTotals(l)
 }
 
+func (l *Logger) HasUpgradeSucceeded() bool {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return len(l.failures) == 0
+}
+
 func logRowFormatTotals(l *Logger) {
 	if len(l.failures) > 0 {
 		l.printf("failed to upgrade %d instances", len(l.failures))

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -128,6 +128,20 @@ var _ = Describe("Logger", func() {
 
 		Expect(result).To(MatchRegexp(timestampRegexp + `: upgraded 2 of 5\n`))
 	})
+
+	Describe("HasUpgradeSucceded", func() {
+		It("can signal upgrade failures", func() {
+			l.UpgradeFailed(upgradeableInstance(1), time.Minute, fmt.Errorf("boom"))
+			Expect(l.HasUpgradeSucceeded()).To(BeFalse())
+		})
+
+		It("can signal upgrade success", func() {
+			l.UpgradeSucceeded(upgradeableInstance(1), time.Minute)
+			l.SkippingInstance(indexedInstance(1, false))
+			Expect(l.HasUpgradeSucceeded()).To(BeTrue())
+		})
+
+	})
 })
 
 func createFailedInstance() ccapi.ServiceInstance {

--- a/internal/upgrader/upgrader.go
+++ b/internal/upgrader/upgrader.go
@@ -26,6 +26,7 @@ type Logger interface {
 	UpgradeFailed(instance ccapi.ServiceInstance, duration time.Duration, err error)
 	DeactivatedPlan(instance ccapi.ServiceInstance)
 	InitialTotals(totalServiceInstances, totalUpgradableServiceInstances int)
+	HasUpgradeSucceeded() bool
 	FinalTotals()
 }
 
@@ -128,6 +129,9 @@ func performUpgrade(api CFClient, upgradableInstances []ccapi.ServiceInstance, p
 	})
 
 	log.FinalTotals()
+	if !log.HasUpgradeSucceeded() {
+		return errors.New("there were failures upgrading one or more instances. Review the logs for more information")
+	}
 	return nil
 }
 

--- a/internal/upgrader/upgraderfakes/fake_logger.go
+++ b/internal/upgrader/upgraderfakes/fake_logger.go
@@ -18,6 +18,16 @@ type FakeLogger struct {
 	finalTotalsMutex       sync.RWMutex
 	finalTotalsArgsForCall []struct {
 	}
+	HasUpgradeSucceededStub        func() bool
+	hasUpgradeSucceededMutex       sync.RWMutex
+	hasUpgradeSucceededArgsForCall []struct {
+	}
+	hasUpgradeSucceededReturns struct {
+		result1 bool
+	}
+	hasUpgradeSucceededReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	InitialTotalsStub        func(int, int)
 	initialTotalsMutex       sync.RWMutex
 	initialTotalsArgsForCall []struct {
@@ -111,6 +121,59 @@ func (fake *FakeLogger) FinalTotalsCalls(stub func()) {
 	fake.finalTotalsMutex.Lock()
 	defer fake.finalTotalsMutex.Unlock()
 	fake.FinalTotalsStub = stub
+}
+
+func (fake *FakeLogger) HasUpgradeSucceeded() bool {
+	fake.hasUpgradeSucceededMutex.Lock()
+	ret, specificReturn := fake.hasUpgradeSucceededReturnsOnCall[len(fake.hasUpgradeSucceededArgsForCall)]
+	fake.hasUpgradeSucceededArgsForCall = append(fake.hasUpgradeSucceededArgsForCall, struct {
+	}{})
+	stub := fake.HasUpgradeSucceededStub
+	fakeReturns := fake.hasUpgradeSucceededReturns
+	fake.recordInvocation("HasUpgradeSucceeded", []interface{}{})
+	fake.hasUpgradeSucceededMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLogger) HasUpgradeSucceededCallCount() int {
+	fake.hasUpgradeSucceededMutex.RLock()
+	defer fake.hasUpgradeSucceededMutex.RUnlock()
+	return len(fake.hasUpgradeSucceededArgsForCall)
+}
+
+func (fake *FakeLogger) HasUpgradeSucceededCalls(stub func() bool) {
+	fake.hasUpgradeSucceededMutex.Lock()
+	defer fake.hasUpgradeSucceededMutex.Unlock()
+	fake.HasUpgradeSucceededStub = stub
+}
+
+func (fake *FakeLogger) HasUpgradeSucceededReturns(result1 bool) {
+	fake.hasUpgradeSucceededMutex.Lock()
+	defer fake.hasUpgradeSucceededMutex.Unlock()
+	fake.HasUpgradeSucceededStub = nil
+	fake.hasUpgradeSucceededReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLogger) HasUpgradeSucceededReturnsOnCall(i int, result1 bool) {
+	fake.hasUpgradeSucceededMutex.Lock()
+	defer fake.hasUpgradeSucceededMutex.Unlock()
+	fake.HasUpgradeSucceededStub = nil
+	if fake.hasUpgradeSucceededReturnsOnCall == nil {
+		fake.hasUpgradeSucceededReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.hasUpgradeSucceededReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeLogger) InitialTotals(arg1 int, arg2 int) {
@@ -317,6 +380,8 @@ func (fake *FakeLogger) Invocations() map[string][][]interface{} {
 	defer fake.deactivatedPlanMutex.RUnlock()
 	fake.finalTotalsMutex.RLock()
 	defer fake.finalTotalsMutex.RUnlock()
+	fake.hasUpgradeSucceededMutex.RLock()
+	defer fake.hasUpgradeSucceededMutex.RUnlock()
 	fake.initialTotalsMutex.RLock()
 	defer fake.initialTotalsMutex.RUnlock()
 	fake.printfMutex.RLock()


### PR DESCRIPTION
Previously the plugin would log a summary with the counts of upgraded, skipped and failed instances plus the details for any failed instances for users to debug and take action. However, if there were instances that failed the upgrade, the exit code would still be 0 making it difficult to find out that there were problems upgrading.

This change is to return a non-zero exit code after printing the summary, when there are one or more instances that failed upgrade. This makes it easier to detect issues upgrading.

[#184640225](https://www.pivotaltracker.com/story/show/184640225)

### Checklist:

~~* [ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
