### PR TITLE
fix: fail on invalid flag combinations

### DIFF
--- a/internal/config/action.go
+++ b/internal/config/action.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Action int
+
+const (
+	InvalidAction Action = iota
+	UpgradeAction
+	DryRunAction
+	CheckUpToDateAction
+	CheckDeactivatedPlansAction
+	MinVersionCheckAction
+)
+
+func determineAction(checkDeactivatedPlans, checkUpToDate, dryRun bool, minVersionRequired string) (Action, error) {
+	spec := map[string]bool{
+		checkDeactivatedPlansFlag: checkDeactivatedPlans,
+		checkUpToDateFlag:         checkUpToDate,
+		dryRunFlag:                dryRun,
+		minVersionRequiredFlag:    minVersionRequired != "",
+	}
+
+	var flagsSpecified []string
+	for k, v := range spec {
+		if v {
+			flagsSpecified = append(flagsSpecified, fmt.Sprintf("--%s", k))
+		}
+	}
+
+	if len(flagsSpecified) > 1 {
+		sort.Strings(flagsSpecified) // Because maps order is random, ensures identical error message each time
+		return InvalidAction, fmt.Errorf("invalid flag combination: %s", strings.Join(flagsSpecified, ", "))
+	}
+
+	switch {
+	case checkDeactivatedPlans:
+		return CheckDeactivatedPlansAction, nil
+	case checkUpToDate:
+		return CheckUpToDateAction, nil
+	case dryRun:
+		return DryRunAction, nil
+	case minVersionRequired != "":
+		return MinVersionCheckAction, nil
+	default:
+		return UpgradeAction, nil
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,50 +4,60 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/go-version"
 )
 
 // Config is the type that contains all the configuration data required to run the plugin
 type Config struct {
-	BrokerName            string
-	APIToken              string
-	APIEndpoint           string
-	SkipSSLValidation     bool
-	HTTPLogging           bool
-	DryRun                bool
-	MinVersionRequired    string
-	CheckUpToDate         bool
-	CheckDeactivatedPlans bool
-	ParallelUpgrades      int
+	Action            Action
+	BrokerName        string
+	APIToken          string
+	APIEndpoint       string
+	SkipSSLValidation bool
+	HTTPLogging       bool
+	MinVersion        *version.Version
+	ParallelUpgrades  int
 }
 
 // ParseConfig combines and validates data from the command line and CLIConnection object
 func ParseConfig(conn CLIConnection, args []string) (Config, error) {
-	var cfg Config
+	var (
+		cfg                   Config
+		dryRun                bool
+		checkUpToDate         bool
+		minVersionRequired    string
+		checkDeactivatedPlans bool
+	)
 
 	flagSet := flag.NewFlagSet("upgrade-all-services", flag.ContinueOnError)
 	flagSet.IntVar(&cfg.ParallelUpgrades, parallelFlag, parallelDefault, parallelDescription)
 	flagSet.BoolVar(&cfg.HTTPLogging, httpLoggingFlag, httpLoggingDefault, httpLoggingDescription)
-	flagSet.BoolVar(&cfg.DryRun, dryRunFlag, dryRunDefault, dryRunDescription)
-	flagSet.BoolVar(&cfg.CheckUpToDate, checkUpToDateFlag, checkUpToDateDefault, checkUpToDateDescription)
-	flagSet.StringVar(&cfg.MinVersionRequired, minVersionRequiredFlag, minVersionRequiredDefault, minVersionRequiredDescription)
-	flagSet.BoolVar(&cfg.CheckDeactivatedPlans, checkDeactivatedPlansFlag, checkDeactivatedPlansDefault, checkDeactivatedPlansDescription)
+	flagSet.BoolVar(&dryRun, dryRunFlag, dryRunDefault, dryRunDescription)
+	flagSet.BoolVar(&checkUpToDate, checkUpToDateFlag, checkUpToDateDefault, checkUpToDateDescription)
+	flagSet.StringVar(&minVersionRequired, minVersionRequiredFlag, minVersionRequiredDefault, minVersionRequiredDescription)
+	flagSet.BoolVar(&checkDeactivatedPlans, checkDeactivatedPlansFlag, checkDeactivatedPlansDefault, checkDeactivatedPlansDescription)
 
 	// This ranges over a chain of functions, each of which performs a single action and may return an error.
 	// The chain breaks at the first error received. It arguably reads better than repetitive error handling logic.
 	for _, s := range []func() error{
+		func() (err error) {
+			cfg.BrokerName, err = parseCommandLine(flagSet, args)
+			return
+		},
+		func() (err error) {
+			cfg.Action, err = determineAction(checkDeactivatedPlans, checkUpToDate, dryRun, minVersionRequired)
+			return
+		},
 		func() error { return validateLoginStatus(conn) },
 		func() error { return validateAPIVersion(conn) },
 		func() error { return read("access token", conn.AccessToken, &cfg.APIToken) },
 		func() error { return read("API endpoint", conn.ApiEndpoint, &cfg.APIEndpoint) },
 		func() error { return read("skip SSL validation", conn.IsSSLDisabled, &cfg.SkipSSLValidation) },
-		func() (err error) {
-			cfg.BrokerName, err = parseCommandLine(flagSet, args)
-			return
-		},
 		func() error { return validateParallelUpgrades(cfg.ParallelUpgrades) },
 		func() error { return validateBrokerName(cfg.BrokerName) },
 		func() (err error) {
-			cfg.MinVersionRequired, err = validateMinVersionRequired(cfg.MinVersionRequired)
+			cfg.MinVersion, err = validateMinVersionRequired(minVersionRequired)
 			return
 		},
 	} {

--- a/internal/config/validations.go
+++ b/internal/config/validations.go
@@ -69,14 +69,14 @@ func validateBrokerName(name string) error {
 	return nil
 }
 
-func validateMinVersionRequired(ver string) (string, error) {
+func validateMinVersionRequired(ver string) (*version.Version, error) {
 	if ver == "" {
-		return "", nil
+		return nil, nil
 	}
 
 	v, err := version.NewVersion(ver)
 	if err != nil {
-		return "", fmt.Errorf("error parsing min-version-required option: %w", err)
+		return nil, fmt.Errorf("error parsing min-version-required option: %w", err)
 	}
-	return v.String(), nil
+	return v, nil
 }

--- a/internal/versionchecker/checker.go
+++ b/internal/versionchecker/checker.go
@@ -10,13 +10,8 @@ type checker struct {
 	minimumVersionRequired *version.Version
 }
 
-func New(minimumRequiredVersion string) (*checker, error) {
-	ver, err := version.NewSemver(minimumRequiredVersion)
-	if err != nil {
-		return nil, fmt.Errorf("incorrect minimum required version: %w", err)
-	}
-
-	return &checker{minimumVersionRequired: ver}, nil
+func New(minimumRequiredVersion *version.Version) (*checker, error) {
+	return &checker{minimumVersionRequired: minimumRequiredVersion}, nil
 }
 
 func (c *checker) IsInstanceVersionLessThanMinimumRequired(instanceVersion string) (bool, error) {

--- a/upgrade_all.go
+++ b/upgrade_all.go
@@ -30,11 +30,9 @@ func upgradeAllServices(cliConnection plugin.CliConnection, args []string) error
 	}
 
 	return upgrader.Upgrade(ccapi.NewCCAPI(reqr), logr, upgrader.UpgradeConfig{
-		BrokerName:            cfg.BrokerName,
-		ParallelUpgrades:      cfg.ParallelUpgrades,
-		DryRun:                cfg.DryRun,
-		MinVersionRequired:    cfg.MinVersionRequired,
-		CheckUpToDate:         cfg.CheckUpToDate,
-		CheckDeactivatedPlans: cfg.CheckDeactivatedPlans,
+		BrokerName:       cfg.BrokerName,
+		ParallelUpgrades: cfg.ParallelUpgrades,
+		Action:           cfg.Action,
+		MinVersion:       cfg.MinVersion,
 	})
 }

--- a/version.go
+++ b/version.go
@@ -9,6 +9,9 @@ import (
 var version = "0.0.0"
 
 func pluginVersion() plugin.VersionType {
+	// NOTE: we use library "github.com/hashicorp/go-version" elsewhere, but it doesn't provide the
+	// ability to easily parse out major/minor/fix, so we use "github.com/blang/semver/v4" here
+	// and only here
 	v := semver.MustParse(version)
 	return plugin.VersionType{
 		Major: int(v.Major),


### PR DESCRIPTION
Previous invalid flag combinations would have performed one action and not performed other specified actions. Now if more than one action is specified, there will be a helpful error message.