### PR TITLE
chore: specify go 1.22.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module upgrade-all-services-cli-plugin
 
-go 1.22
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible


### PR DESCRIPTION
Related PRs:
- https://github.com/pivotal/cloud-service-broker-ci/pull/795

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
