### PR TITLE
chore: make codeql action use golang specified in go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,13 @@ jobs:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
+      # Install golang used by this project (https://github.com/github/codeql-action/issues/1842)
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+
+
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
 


### PR DESCRIPTION
Related PRs:
- https://github.com/argentumcode/systemd-failure-pagerduty/pull/8/files
- https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/pull/133

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
