### PR TITLE
fix: fix failures due to go 1.24

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -16,7 +16,7 @@ func New(period time.Duration) *Logger {
 
 	go func() {
 		for range l.ticker.C {
-			l.Printf(l.tickerMessage())
+			l.Printf("%s", l.tickerMessage())
 		}
 	}()
 
@@ -116,7 +116,7 @@ func (l *Logger) FinalTotals() {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
-	l.printf(l.tickerMessage())
+	l.printf("%s", l.tickerMessage())
 	l.separator()
 	l.printf("skipped %d instances", l.skipped)
 	l.printf("successfully upgraded %d instances", l.successes)


### PR DESCRIPTION
Changes to satisfy Go 1.24 new requirement for format strings to be constants.