### PR TITLE
test: integration test for minimum version detection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,12 @@ jobs:
       with:
         go-version: '1.25.1'
     - uses: actions/checkout@v5
-    - run: make test
+    - run: |
+        wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo gpg --dearmor -o /usr/share/keyrings/cli.cloudfoundry.org.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cli.cloudfoundry.org.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+        sudo apt-get update
+        sudo apt-get install -y cf8-cli
+        make test
   call-dependabot-pr-workflow:
     needs: test
     if: ${{ success() && github.actor == 'dependabot[bot]' }}

--- a/integrationtests/integrationtests_suite_test.go
+++ b/integrationtests/integrationtests_suite_test.go
@@ -1,0 +1,59 @@
+package integrationtests_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+	"upgrade-all-services-cli-plugin/internal/fakecapi"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var (
+	cfPath string
+	capi   *fakecapi.FakeCAPI
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Tests Suite")
+}
+
+var _ = SynchronizedBeforeSuite(
+	func() []byte {
+		cf, err := exec.LookPath("cf")
+		Expect(err).NotTo(HaveOccurred(), "The 'cf' executable is a pre-requisite for running this test")
+
+		plugin, err := Build("upgrade-all-services-cli-plugin")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(CleanupBuildArtifacts)
+
+		session, err := Start(exec.Command(cf, "install-plugin", "-f", plugin), GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
+
+		return []byte(cf)
+	},
+	func(input []byte) {
+		cfPath = string(input)
+	},
+)
+
+var _ = BeforeEach(func() {
+	capi = fakecapi.New()
+	DeferCleanup(func() {
+		capi.Stop()
+	})
+
+	Eventually(cf("api", "--skip-ssl-validation", capi.URL)).WithTimeout(time.Minute).Should(Exit(0))
+	Eventually(cf("auth", "foo", "bar")).WithTimeout(time.Minute).Should(Exit(0))
+})
+
+func cf(args ...string) *Session {
+	cmd := exec.Command(cfPath, args...)
+	session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	return session
+}

--- a/integrationtests/min_version_required_test.go
+++ b/integrationtests/min_version_required_test.go
@@ -1,0 +1,174 @@
+package integrationtests_test
+
+import (
+	"strings"
+	"time"
+	"upgrade-all-services-cli-plugin/internal/fakecapi"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("MinVersionRequired", func() {
+	const brokerName = "min-ver-broker"
+
+	BeforeEach(func() {
+		capi.AddBroker(
+			fakecapi.ServiceBroker{Name: brokerName},
+			fakecapi.WithServiceOffering(
+				fakecapi.ServiceOffering{Name: "service-offering-1"},
+				fakecapi.WithServicePlan(
+					fakecapi.ServicePlan{Name: "service-plan1", Version: "1.2.3"},
+					fakecapi.WithServiceInstances(
+						fakecapi.ServiceInstance{Name: "service-instance-1", Version: "1.2.3"},
+						fakecapi.ServiceInstance{Name: "service-instance-2", Version: "1.2.2"},
+					),
+				),
+				fakecapi.WithServicePlan(
+					fakecapi.ServicePlan{Name: "service-plan-2", Version: "1.2.3"},
+					fakecapi.WithServiceInstances(
+						fakecapi.ServiceInstance{Name: "service-instance-3", Version: "1.2.0"},
+					),
+				),
+			),
+			fakecapi.WithServiceOffering(
+				fakecapi.ServiceOffering{Name: "service-offering-2"},
+				fakecapi.WithServicePlan(
+					fakecapi.ServicePlan{Name: "service-plan-3", Version: "1.2.3"},
+					fakecapi.WithServiceInstances(
+						fakecapi.ServiceInstance{Name: "service-instance-4", Version: "1.2.1"},
+					),
+				),
+			),
+		)
+	})
+
+	It("detects versions below the minimum", func() {
+		session := cf("upgrade-all-services", brokerName, "-min-version-required", "1.2.3")
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
+		Expect(session.Out).To(Say(strings.TrimSpace(`
+\S+: discovering service instances for broker: min-ver-broker
+\S+: ---
+\S+: total instances: 4
+\S+: upgradable instances: 3
+\S+: ---
+\S+: starting upgrade...
+\S+: upgrade of instance: "service-instance-2" guid: "\S+" failed after 0s: dry-run prevented upgrade instance guid \S+
+\S+: upgrade of instance: "service-instance-3" guid: "\S+" failed after 0s: dry-run prevented upgrade instance guid \S+
+\S+: upgrade of instance: "service-instance-4" guid: "\S+" failed after 0s: dry-run prevented upgrade instance guid \S+
+\S+: upgraded 3 of 3
+\S+: ---
+\S+: skipped 0 instances
+\S+: successfully upgraded 0 instances
+\S+: failed to upgrade 3 instances
+\S+:\s
+
+\s+Service Instance Name: "service-instance-2"
+\s+Service Instance GUID: "\S+"
+\s+Service Version: "1.2.2"
+\s+Details: "dry-run prevented upgrade instance guid \S+"
+\s+Org Name: "fake-org"
+\s+Org GUID: "\S+"
+\s+Space Name: "fake-space"
+\s+Space GUID: "\S+"
+\s+Plan Name: "service-plan1"
+\s+Plan GUID: "\S+"
+\s+Plan Version: "1.2.3"
+\s+Service Offering Name: "service-offering-1"
+\s+Service Offering GUID: "\S+"
+
+
+\s+Service Instance Name: "service-instance-3"
+\s+Service Instance GUID: "\S+"
+\s+Service Version: "1.2.0"
+\s+Details: "dry-run prevented upgrade instance guid \S+"
+\s+Org Name: "fake-org"
+\s+Org GUID: "\S+"
+\s+Space Name: "fake-space"
+\s+Space GUID: "\S+"
+\s+Plan Name: "service-plan-2"
+\s+Plan GUID: "\S+"
+\s+Plan Version: "1.2.3"
+\s+Service Offering Name: "service-offering-1"
+\s+Service Offering GUID: "\S+"
+
+
+\s+Service Instance Name: "service-instance-4"
+\s+Service Instance GUID: "\S+"
+\s+Service Version: "1.2.1"
+\s+Details: "dry-run prevented upgrade instance guid \S+"
+\s+Org Name: "fake-org"
+\s+Org GUID: "\S+"
+\s+Space Name: "fake-space"
+\s+Space GUID: "\S+"
+\s+Plan Name: "service-plan-3"
+\s+Plan GUID: "\S+"
+\s+Plan Version: "1.2.3"
+\s+Service Offering Name: "service-offering-2"
+\s+Service Offering GUID: "\S+"
+`)))
+		Expect(session.Err).To(Say(`upgrade-all-services plugin failed: found 3 service instances with a version less than the minimum required`))
+	})
+
+	It("ignores versions at or above the minimum", func() {
+		session := cf("upgrade-all-services", brokerName, "-min-version-required", "1.2.2")
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
+		Expect(session.Out).To(Say(strings.TrimSpace(`
+\S+: discovering service instances for broker: min-ver-broker
+\S+: ---
+\S+: total instances: 4
+\S+: upgradable instances: 2
+\S+: ---
+\S+: starting upgrade...
+\S+: upgrade of instance: "service-instance-3" guid: "\S+" failed after 0s: dry-run prevented upgrade instance guid \S+
+\S+: upgrade of instance: "service-instance-4" guid: "\S+" failed after 0s: dry-run prevented upgrade instance guid \S+
+\S+: upgraded 2 of 2
+\S+: ---
+\S+: skipped 0 instances
+\S+: successfully upgraded 0 instances
+\S+: failed to upgrade 2 instances
+\S+: 
+
+\s+Service Instance Name: "service-instance-3"
+\s+Service Instance GUID: "\S+"
+\s+Service Version: "1.2.0"
+\s+Details: "dry-run prevented upgrade instance guid \S+"
+\s+Org Name: "fake-org"
+\s+Org GUID: "\S+"
+\s+Space Name: "fake-space"
+\s+Space GUID: "\S+"
+\s+Plan Name: "service-plan-2"
+\s+Plan GUID: "\S+"
+\s+Plan Version: "1.2.3"
+\s+Service Offering Name: "service-offering-1"
+\s+Service Offering GUID: "\S+"
+
+
+\s+Service Instance Name: "service-instance-4"
+\s+Service Instance GUID: "\S+"
+\s+Service Version: "1.2.1"
+\s+Details: "dry-run prevented upgrade instance guid \S+"
+\s+Org Name: "fake-org"
+\s+Org GUID: "\S+"
+\s+Space Name: "fake-space"
+\s+Space GUID: "\S+"
+\s+Plan Name: "service-plan-3"
+\s+Plan GUID: "\S+"
+\s+Plan Version: "1.2.3"
+\s+Service Offering Name: "service-offering-2"
+\s+Service Offering GUID: "\S+"
+`)))
+		Expect(session.Err).To(Say(`upgrade-all-services plugin failed: found 2 service instances with a version less than the minimum required`))
+	})
+
+	It("succeeds when all instances are at or above the minimum", func() {
+		session := cf("upgrade-all-services", brokerName, "-min-version-required", "1.2.0")
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
+		Expect(session.Out).To(Say(strings.TrimSpace(`
+\S+: discovering service instances for broker: min-ver-broker
+\S+: no instances found with version less than required
+`)))
+	})
+})

--- a/internal/fakecapi/brokers.go
+++ b/internal/fakecapi/brokers.go
@@ -1,0 +1,20 @@
+package fakecapi
+
+func (f *FakeCAPI) AddBroker(broker ServiceBroker, opts ...func(*FakeCAPI, ServiceBroker)) {
+	if broker.Name == "" {
+		broker.Name = guid()
+	}
+	if broker.GUID == "" {
+		broker.GUID = guid()
+	}
+
+	f.brokers[broker.GUID] = broker
+	for _, opt := range opts {
+		opt(f, broker)
+	}
+}
+
+type ServiceBroker struct {
+	Name string
+	GUID string
+}

--- a/internal/fakecapi/fakecapi.go
+++ b/internal/fakecapi/fakecapi.go
@@ -1,0 +1,132 @@
+// Package fakecapi is a test fake for the Cloud Controller API
+package fakecapi
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// fakeJWT is a valid JWT generated using http://jwt.io with a payload "exp" of 9999999999
+const fakeJWT = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjo5OTk5OTk5OTk5fQ.t4hnLA9gcRfu_W3_KpcS1UjCEl4xyDmEHUVODobhgAk`
+
+func New() *FakeCAPI {
+	loginPort, err := freePort()
+	if err != nil {
+		panic(err)
+	}
+
+	capiPort, err := freePort()
+	if err != nil {
+		panic(err)
+	}
+
+	f := FakeCAPI{
+		URL:       fmt.Sprintf("http://localhost:%d", capiPort),
+		loginURL:  fmt.Sprintf("http://localhost:%d", loginPort),
+		brokers:   make(map[string]ServiceBroker),
+		plans:     make(map[string]ServicePlan),
+		offerings: make(map[string]ServiceOffering),
+		instances: make(map[string]ServiceInstance),
+	}
+
+	f.stopLogin = start(loginMux(), loginPort)
+	f.stopCAPI = start(f.capiMux(), capiPort)
+
+	return &f
+}
+
+type FakeCAPI struct {
+	URL       string
+	loginURL  string
+	stopLogin func()
+	stopCAPI  func()
+	brokers   map[string]ServiceBroker
+	plans     map[string]ServicePlan
+	offerings map[string]ServiceOffering
+	instances map[string]ServiceInstance
+}
+
+func (f *FakeCAPI) Stop() {
+	f.stopLogin()
+	f.stopCAPI()
+}
+
+func (f *FakeCAPI) capiMux() *http.ServeMux {
+	capi := http.NewServeMux()
+
+	capi.HandleFunc("GET /v2/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"api_version":"2.264.0"}`))
+	})
+
+	capi.HandleFunc("GET /v3/service_plans", f.servicePlanHandler())
+	capi.HandleFunc("GET /v3/service_instances", f.serviceInstanceHandler())
+
+	capi.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Write(fmt.Appendf(nil, `{"links":{"login":{"href":"%s"},"cloud_controller_v3":{"href":"%s/v3","meta":{"version":"3.199.0"}},"cloud_controller_v2":{"href":"%s/v2","meta":{"version":"2.264.0"}}}}`, f.loginURL, f.URL, f.URL))
+			return
+		}
+
+		http.NotFound(w, r)
+	})
+
+	return capi
+}
+
+func loginMux() *http.ServeMux {
+	login := http.NewServeMux()
+	login.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(fmt.Appendf(nil, `{"access_token":"%s"}`, fakeJWT))
+	})
+
+	return login
+}
+
+func start(handler http.Handler, port int) (stop func()) {
+	svr := http.Server{
+		Addr:    fmt.Sprintf("localhost:%d", port),
+		Handler: handler,
+	}
+
+	go func() {
+		if err := svr.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	return func() {
+		_ = svr.Shutdown(context.Background())
+	}
+}
+
+func freePort() (int, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
+func guid() string {
+	data := make([]byte, 16)
+	if _, err := rand.Read(data); err != nil {
+		panic(err)
+	}
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", data[0:4], data[4:6], data[6:8], data[8:10], data[10:])
+}
+
+func filter[A any](a []A, cb func(A) bool) (result []A) {
+	for _, v := range a {
+		if cb(v) {
+			result = append(result, v)
+		}
+	}
+	return
+}

--- a/internal/fakecapi/instances.go
+++ b/internal/fakecapi/instances.go
@@ -1,0 +1,117 @@
+package fakecapi
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"code.cloudfoundry.org/jsonry"
+)
+
+const (
+	spaceGUID = "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
+	orgGUID   = "1a2f43b5-1594-4247-a888-e8843ebd1b03"
+)
+
+func WithServiceInstances(instances ...ServiceInstance) func(*FakeCAPI, ServicePlan) {
+	return func(f *FakeCAPI, plan ServicePlan) {
+		for _, instance := range instances {
+			if instance.Name == "" {
+				instance.Name = guid()
+			}
+			if instance.GUID == "" {
+				instance.GUID = guid()
+			}
+			instance.ServicePlanName = plan.Name
+			instance.ServicePlanGUID = plan.GUID
+			instance.ServiceOfferingName = plan.ServiceOfferingName
+			instance.ServiceOfferingGUID = plan.ServiceOfferingGUID
+			instance.SpaceGUID = spaceGUID
+
+			f.instances[instance.GUID] = instance
+		}
+	}
+}
+
+type ServiceInstance struct {
+	Name                string `json:"name"`
+	GUID                string `json:"guid"`
+	ServicePlanGUID     string `jsonry:"relationships.service_plan.data.guid"`
+	SpaceGUID           string `jsonry:"relationships.space.data.guid"`
+	ServicePlanName     string `json:"-"`
+	ServiceOfferingGUID string `json:"-"`
+	ServiceOfferingName string `json:"-"`
+	Version             string `jsonry:"maintenance_info.version"`
+	UpgradeAvailable    bool   `json:"upgrade_available"`
+	LastOperationType   string `jsonry:"last_operation.type"`
+	LastOperationState  string `jsonry:"last_operation.state"`
+}
+
+type Space struct {
+	Name             string `json:"name"`
+	GUID             string `json:"guid"`
+	OrganizationName string `jsonry:"relationships.organization.date.name"`
+	OrganizationGUID string `jsonry:"relationships.organization.data.guid"`
+}
+
+type Org struct {
+	Name string `json:"name"`
+	GUID string `json:"guid"`
+}
+
+func (f *FakeCAPI) serviceInstanceHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		includeSpaces, includeOrgs := false, false
+
+		instances := slices.Collect(maps.Values(f.instances))
+		for k := range r.URL.Query() {
+			v := r.URL.Query().Get(k)
+			switch {
+			case k == "per_page": // ignore
+			case k == "fields[space]" && v == "name,guid,relationships.organization":
+				includeSpaces = true
+			case k == "fields[space.organization]" && v == "name,guid":
+				includeOrgs = true
+			case k == "service_plan_guids":
+				instances = filter(instances, func(p ServiceInstance) bool { return slices.Contains(strings.Split(v, ","), p.ServicePlanGUID) })
+			default:
+				http.Error(w, fmt.Sprintf("unknown query filter %q with value %q", k, v), http.StatusBadRequest)
+				return
+			}
+		}
+
+		var includedSpaces []Space
+		if includeSpaces {
+			includedSpaces = append(includedSpaces, Space{
+				Name:             "fake-space",
+				GUID:             spaceGUID,
+				OrganizationName: "fake-org",
+				OrganizationGUID: orgGUID,
+			})
+		}
+
+		var includedOrgs []Org
+		if includeOrgs {
+			includedOrgs = append(includedOrgs, Org{
+				Name: "fake-org",
+				GUID: orgGUID,
+			})
+		}
+
+		slices.SortStableFunc(instances, func(a, b ServiceInstance) int { return strings.Compare(a.Name, b.Name) })
+
+		payload, err := jsonry.Marshal(struct {
+			Resources      []ServiceInstance `json:"resources"`
+			IncludedSpaces []Space           `jsonry:"included.spaces,omitempty"`
+			IncludedOrgs   []Org             `jsonry:"included.organizations,omitempty"`
+		}{Resources: instances, IncludedSpaces: includedSpaces, IncludedOrgs: includedOrgs})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Write(payload)
+	}
+}

--- a/internal/fakecapi/offerings.go
+++ b/internal/fakecapi/offerings.go
@@ -1,0 +1,27 @@
+package fakecapi
+
+func WithServiceOffering(offering ServiceOffering, opts ...func(*FakeCAPI, ServiceOffering)) func(*FakeCAPI, ServiceBroker) {
+	return func(f *FakeCAPI, broker ServiceBroker) {
+		if offering.Name == "" {
+			offering.Name = guid()
+		}
+		if offering.GUID == "" {
+			offering.GUID = guid()
+		}
+		offering.ServiceBrokerName = broker.Name
+		offering.ServiceBrokerGUID = broker.GUID
+
+		f.offerings[offering.GUID] = offering
+
+		for _, opt := range opts {
+			opt(f, offering)
+		}
+	}
+}
+
+type ServiceOffering struct {
+	Name              string `json:"name"`
+	GUID              string `json:"guid"`
+	ServiceBrokerName string `json:"-"`
+	ServiceBrokerGUID string `json:"-"`
+}

--- a/internal/fakecapi/plans.go
+++ b/internal/fakecapi/plans.go
@@ -1,0 +1,81 @@
+package fakecapi
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"code.cloudfoundry.org/jsonry"
+)
+
+func WithServicePlan(plan ServicePlan, opts ...func(*FakeCAPI, ServicePlan)) func(*FakeCAPI, ServiceOffering) {
+	return func(f *FakeCAPI, offering ServiceOffering) {
+		if plan.Name == "" {
+			plan.Name = guid()
+		}
+		if plan.GUID == "" {
+			plan.GUID = guid()
+		}
+		plan.ServiceOfferingName = offering.Name
+		plan.ServiceOfferingGUID = offering.GUID
+
+		f.plans[plan.GUID] = plan
+
+		for _, opt := range opts {
+			opt(f, plan)
+		}
+	}
+}
+
+type ServicePlan struct {
+	Name                string `json:"name"`
+	GUID                string `json:"guid"`
+	Version             string `jsonry:"maintenance_info.version"`
+	ServiceOfferingName string `json:"-"`
+	ServiceOfferingGUID string `jsonry:"relationships.service_offering.data.guid"`
+}
+
+func (f *FakeCAPI) servicePlanHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		includeServiceOffering := false
+
+		plans := slices.Collect(maps.Values(f.plans))
+		for k := range r.URL.Query() {
+			v := r.URL.Query().Get(k)
+			switch {
+			case k == "per_page": // ignore
+			case k == "include" && v == "service_offering":
+				includeServiceOffering = true
+			case k == "service_broker_names":
+				plans = filter(plans, func(p ServicePlan) bool {
+					return slices.Contains(strings.Split(v, ","), f.offerings[p.ServiceOfferingGUID].ServiceBrokerName)
+				})
+			default:
+				http.Error(w, fmt.Sprintf("unknown query filter %q with value %q", k, v), http.StatusBadRequest)
+				return
+			}
+		}
+
+		includedOfferings := make(map[string]ServiceOffering)
+		if includeServiceOffering {
+			for _, p := range plans {
+				includedOfferings[p.ServiceOfferingGUID] = f.offerings[p.ServiceOfferingGUID]
+			}
+		}
+
+		slices.SortStableFunc(plans, func(a, b ServicePlan) int { return strings.Compare(a.Name, b.Name) })
+
+		payload, err := jsonry.Marshal(struct {
+			Resources         []ServicePlan     `json:"resources"`
+			IncludedOfferings []ServiceOffering `jsonry:"included.service_offerings,omitempty"`
+		}{Resources: plans, IncludedOfferings: slices.Collect(maps.Values(includedOfferings))})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Write(payload)
+	}
+}


### PR DESCRIPTION
The testing in this plugin is mainly of individual components and not of the system as a whole. This commit introduces some testing of the plugin as a whole, by creating a fake CAPI backend and running the plugin via the CF CLI. This testing is still fast and reliable, and tests behavior rather than implementation: allowing for refactoring of the internals with low risk of changing behavior.