### PR TITLE
test: use normal length GUIDs in tests

### DIFF
--- a/integrationtests/check_deactivated_plans_test.go
+++ b/integrationtests/check_deactivated_plans_test.go
@@ -61,8 +61,8 @@ var _ = Describe("-check-deactivated-plans", func() {
 		Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
 		Expect(session.Out).To(Say(strings.TrimSpace(`
 \S+: discovering service instances for broker: check-deactivated-plans-broker
-\S+: skipping instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae" Deactivated Plan: "service-plan-2" Offering: "service-offering-1" Offering guid: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760" Upgrade Available: true Last Operation Type: "create" State: "succeeded"
-\S+: skipping instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9" Deactivated Plan: "service-plan-3" Offering: "service-offering-2" Offering guid: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea4412b95dbebf58dda02ee194c7c4598b" Upgrade Available: false Last Operation Type: "update" State: "failed"
+\S+: skipping instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358c" Deactivated Plan: "service-plan-2" Offering: "service-offering-1" Offering guid: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa" Upgrade Available: true Last Operation Type: "create" State: "succeeded"
+\S+: skipping instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af0" Deactivated Plan: "service-plan-3" Offering: "service-offering-2" Offering guid: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea" Upgrade Available: false Last Operation Type: "update" State: "failed"
 `)))
 
 		Expect(string(session.Out.Contents())).NotTo(SatisfyAny(

--- a/integrationtests/check_up_to_date_test.go
+++ b/integrationtests/check_up_to_date_test.go
@@ -55,9 +55,9 @@ var _ = Describe("-check-up-to-date", func() {
 \S+: upgradable instances: 2
 \S+: ---
 \S+: starting upgrade...
-\S+: upgrade of instance: "service-instance-2" guid: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359" failed after 0s: dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359
-\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae
-\S+: skipping instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9" Deactivated Plan: "service-plan-3" Offering: "service-offering-2" Offering guid: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea4412b95dbebf58dda02ee194c7c4598b" Upgrade Available: false Last Operation Type: "create" State: "succeeded"
+\S+: upgrade of instance: "service-instance-2" guid: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f" failed after 0s: dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f
+\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358c" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c
+\S+: skipping instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af0" Deactivated Plan: "service-plan-3" Offering: "service-offering-2" Offering guid: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea" Upgrade Available: false Last Operation Type: "create" State: "succeeded"
 \S+: upgraded 2 of 2
 \S+: ---
 \S+: skipped 1 instances
@@ -66,33 +66,33 @@ var _ = Describe("-check-up-to-date", func() {
 \S+: 
 
 \s+Service Instance Name: "service-instance-2"
-\s+Service Instance GUID: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359"
+\s+Service Instance GUID: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f"
 \s+Service Version: "1.2.2"
-\s+Details: "dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359"
+\s+Details: "dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan1"
-\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14254a50e4ad138cb08b109433e249a934"
+\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 
 
 \s+Service Instance Name: "service-instance-3"
-\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Service Version: "1.2.0"
-\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-2"
-\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02a8992444e56e9743dd4de35058e8373d"
+\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 `)))
 		Expect(session.Err).To(Say(strings.TrimSpace(`
 upgrade-all-services plugin failed: found 2 instances which are not up-to-date

--- a/integrationtests/dry_run_test.go
+++ b/integrationtests/dry_run_test.go
@@ -55,9 +55,9 @@ var _ = Describe("-dry-run", func() {
 \S+: upgradable instances: 3
 \S+: ---
 \S+: starting upgrade...
-\S+: upgrade of instance: "service-instance-1" guid: "5cc87b43-f885-3b94-328f-8a5f953590d341f6730f5ba530f723a6ab0fea651bf6" failed after 0s: dry-run prevented upgrade instance guid 5cc87b43-f885-3b94-328f-8a5f953590d341f6730f5ba530f723a6ab0fea651bf6
-\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae
-\S+: upgrade of instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9" failed after 0s: dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9
+\S+: upgrade of instance: "service-instance-1" guid: "5cc87b43-f885-3b94-328f-8a5f953590d3" failed after 0s: dry-run prevented upgrade instance guid 5cc87b43-f885-3b94-328f-8a5f953590d3
+\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358c" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c
+\S+: upgrade of instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af0" failed after 0s: dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af0
 \S+: upgraded 3 of 3
 \S+: ---
 \S+: skipped 0 instances
@@ -66,48 +66,48 @@ var _ = Describe("-dry-run", func() {
 \S+: 
 
 \s+Service Instance Name: "service-instance-1"
-\s+Service Instance GUID: "5cc87b43-f885-3b94-328f-8a5f953590d341f6730f5ba530f723a6ab0fea651bf6"
+\s+Service Instance GUID: "5cc87b43-f885-3b94-328f-8a5f953590d3"
 \s+Service Version: "1.2.2"
-\s+Details: "dry-run prevented upgrade instance guid 5cc87b43-f885-3b94-328f-8a5f953590d341f6730f5ba530f723a6ab0fea651bf6"
+\s+Details: "dry-run prevented upgrade instance guid 5cc87b43-f885-3b94-328f-8a5f953590d3"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan1"
-\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14254a50e4ad138cb08b109433e249a934"
+\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 
 
 \s+Service Instance Name: "service-instance-3"
-\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Service Version: "1.1.0"
-\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-2"
-\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02a8992444e56e9743dd4de35058e8373d"
+\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02"
 \s+Plan Version: "1.2.0"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 
 
 \s+Service Instance Name: "service-instance-4"
-\s+Service Instance GUID: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9"
+\s+Service Instance GUID: "c53ccd0e-b88e-0d93-712d-609588651af0"
 \s+Service Version: "1.2.9"
-\s+Details: "dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9"
+\s+Details: "dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af0"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-3"
-\s+Plan GUID: "51f29f1b-d343-6bdd-0192-deb80d4c6d9f15383c397664b3d6c28372cd53816129"
+\s+Plan GUID: "51f29f1b-d343-6bdd-0192-deb80d4c6d9f"
 \s+Plan Version: "1.3.0"
 \s+Service Offering Name: "service-offering-2"
-\s+Service Offering GUID: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea4412b95dbebf58dda02ee194c7c4598b"
+\s+Service Offering GUID: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea"
 `)))
 	})
 })

--- a/integrationtests/min_version_required_test.go
+++ b/integrationtests/min_version_required_test.go
@@ -55,9 +55,9 @@ var _ = Describe("-min-version-required", func() {
 \S+: upgradable instances: 3
 \S+: ---
 \S+: starting upgrade...
-\S+: upgrade of instance: "service-instance-2" guid: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359" failed after 0s: dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359
-\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae
-\S+: upgrade of instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9" failed after 0s: dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9
+\S+: upgrade of instance: "service-instance-2" guid: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f" failed after 0s: dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f
+\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358c" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c
+\S+: upgrade of instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af0" failed after 0s: dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af0
 \S+: upgraded 3 of 3
 \S+: ---
 \S+: skipped 0 instances
@@ -66,48 +66,48 @@ var _ = Describe("-min-version-required", func() {
 \S+:\s
 
 \s+Service Instance Name: "service-instance-2"
-\s+Service Instance GUID: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359"
+\s+Service Instance GUID: "0ec2261c-5d50-c12e-4e8b-ca9273c6150f"
 \s+Service Version: "1.2.2"
-\s+Details: "dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f34d21395d3d2d8d244769fc2ceafa359"
+\s+Details: "dry-run prevented upgrade instance guid 0ec2261c-5d50-c12e-4e8b-ca9273c6150f"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan1"
-\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14254a50e4ad138cb08b109433e249a934"
+\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 
 
 \s+Service Instance Name: "service-instance-3"
-\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Service Version: "1.2.0"
-\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-2"
-\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02a8992444e56e9743dd4de35058e8373d"
+\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 
 
 \s+Service Instance Name: "service-instance-4"
-\s+Service Instance GUID: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9"
+\s+Service Instance GUID: "c53ccd0e-b88e-0d93-712d-609588651af0"
 \s+Service Version: "1.2.1"
-\s+Details: "dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9"
+\s+Details: "dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af0"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-3"
-\s+Plan GUID: "51f29f1b-d343-6bdd-0192-deb80d4c6d9f15383c397664b3d6c28372cd53816129"
+\s+Plan GUID: "51f29f1b-d343-6bdd-0192-deb80d4c6d9f"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-2"
-\s+Service Offering GUID: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea4412b95dbebf58dda02ee194c7c4598b"
+\s+Service Offering GUID: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea"
 `)))
 		Expect(session.Err).To(Say(`upgrade-all-services plugin failed: found 3 service instances with a version less than the minimum required`))
 	})
@@ -122,8 +122,8 @@ var _ = Describe("-min-version-required", func() {
 \S+: upgradable instances: 2
 \S+: ---
 \S+: starting upgrade...
-\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae
-\S+: upgrade of instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9" failed after 0s: dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9
+\S+: upgrade of instance: "service-instance-3" guid: "ef7fa19f-0d66-55d0-0519-f198164d358c" failed after 0s: dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c
+\S+: upgrade of instance: "service-instance-4" guid: "c53ccd0e-b88e-0d93-712d-609588651af0" failed after 0s: dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af0
 \S+: upgraded 2 of 2
 \S+: ---
 \S+: skipped 0 instances
@@ -132,33 +132,33 @@ var _ = Describe("-min-version-required", func() {
 \S+: 
 
 \s+Service Instance Name: "service-instance-3"
-\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Service Instance GUID: "ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Service Version: "1.2.0"
-\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358ce662614b25499cd4ebf411f5e6ea55ae"
+\s+Details: "dry-run prevented upgrade instance guid ef7fa19f-0d66-55d0-0519-f198164d358c"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-2"
-\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02a8992444e56e9743dd4de35058e8373d"
+\s+Plan GUID: "3ccc0ed1-1c06-036b-7bfe-f4d9dff25d02"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 
 
 \s+Service Instance Name: "service-instance-4"
-\s+Service Instance GUID: "c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9"
+\s+Service Instance GUID: "c53ccd0e-b88e-0d93-712d-609588651af0"
 \s+Service Version: "1.2.1"
-\s+Details: "dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af020db5207350e8f031a12585cef7accd9"
+\s+Details: "dry-run prevented upgrade instance guid c53ccd0e-b88e-0d93-712d-609588651af0"
 \s+Org Name: "fake-org"
 \s+Org GUID: "1a2f43b5-1594-4247-a888-e8843ebd1b03"
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan-3"
-\s+Plan GUID: "51f29f1b-d343-6bdd-0192-deb80d4c6d9f15383c397664b3d6c28372cd53816129"
+\s+Plan GUID: "51f29f1b-d343-6bdd-0192-deb80d4c6d9f"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-2"
-\s+Service Offering GUID: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea4412b95dbebf58dda02ee194c7c4598b"
+\s+Service Offering GUID: "dda79e55-6ef6-5f90-4cd7-174fb300b1ea"
 `)))
 		Expect(session.Err).To(Say(`upgrade-all-services plugin failed: found 2 service instances with a version less than the minimum required`))
 	})

--- a/integrationtests/upgrade_test.go
+++ b/integrationtests/upgrade_test.go
@@ -100,16 +100,16 @@ var _ = Describe("upgrade", func() {
 			Expect(capi.UpdateCount()).To(Equal(15))
 
 			expectedFailures := map[string]string{
-				"fake-instance-6":  "07b9b83d-419e-b968-7a61-d55895af3466fcc76eabeaa4bc0735c5b605306d0738",
-				"fake-instance-7":  "8df19a1a-63d4-5789-3427-228f485e03fda46ac199eb215ef943e3bccde9ffd852",
-				"fake-instance-8":  "73bd62c1-94ab-e6ec-6ffc-24c994b124d535125bff49dac290158b0a25039f6ee3",
-				"fake-instance-9":  "036b82e1-6bea-1db0-81ec-b0b6628a67ae8e21d596149404f6974d6848f14edd28",
-				"fake-instance-10": "5e1f4213-272c-0d56-1fdb-d6f85a0d71cfe73a922572b972153d1e855fc7f406ac",
-				"fake-instance-11": "43645af7-94b7-7880-6a66-ea39704bc7308c3b669104787ff4c1575a7468d3f80b",
-				"fake-instance-12": "abca2199-4ddb-7537-ba3f-84b0ed4722448fa8e538f272409c9d4a3cac33478229",
-				"fake-instance-13": "228ffe48-1f51-2b7b-5da5-ca114987697c6a8971d1407854c137a9d2ecd197cc33",
-				"fake-instance-14": "ae92ddf7-ca98-8f3f-048f-2d7ead0ff3e1919cdea572c55dcfabac5aadc21f7b95",
-				"fake-instance-15": "c23c4e8b-1fbb-5aef-ef5b-fc7bcfd120ce2af37f5658d0c154e5772d10e34f5b42",
+				"fake-instance-6":  "07b9b83d-419e-b968-7a61-d55895af3466",
+				"fake-instance-7":  "8df19a1a-63d4-5789-3427-228f485e03fd",
+				"fake-instance-8":  "73bd62c1-94ab-e6ec-6ffc-24c994b124d5",
+				"fake-instance-9":  "036b82e1-6bea-1db0-81ec-b0b6628a67ae",
+				"fake-instance-10": "5e1f4213-272c-0d56-1fdb-d6f85a0d71cf",
+				"fake-instance-11": "43645af7-94b7-7880-6a66-ea39704bc730",
+				"fake-instance-12": "abca2199-4ddb-7537-ba3f-84b0ed472244",
+				"fake-instance-13": "228ffe48-1f51-2b7b-5da5-ca114987697c",
+				"fake-instance-14": "ae92ddf7-ca98-8f3f-048f-2d7ead0ff3e1",
+				"fake-instance-15": "c23c4e8b-1fbb-5aef-ef5b-fc7bcfd120ce",
 			}
 
 			for name, guid := range expectedFailures {
@@ -125,19 +125,19 @@ var _ = Describe("upgrade", func() {
 \s+Space Name: "fake-space"
 \s+Space GUID: "5f870ea3-fa54-4174-ab3f-15f2d9516e07"
 \s+Plan Name: "service-plan1"
-\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14254a50e4ad138cb08b109433e249a934"
+\s+Plan GUID: "173a3f22-e23f-27f2-9b32-8efdb64d5c14"
 \s+Plan Version: "1.2.3"
 \s+Service Offering Name: "service-offering-1"
-\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa2e7736a44b2e4ea39df28a5c1e96c760"
+\s+Service Offering GUID: "7fb1c0fc-45b4-fb4d-5aa5-2d2011573daa"
 `, name, guid))))
 			}
 
 			expectedSuccesses := map[string]string{
-				"fake-instance-1": "23525d72-bd78-5a0e-283b-cca10567e5c039c4791506dfe91297255359639054c8",
-				"fake-instance-2": "31dc65f7-0792-446a-024b-6b6fe613f99f21244c8d14ae2fb58e88a348502fdcf7",
-				"fake-instance-3": "285c7aac-ff1f-54ea-94ae-10e28f191b5a031b9a6de68ed094cc285fb62fe6893c",
-				"fake-instance-4": "e2b68b0d-3f8c-7a7f-facc-493f8dd1353feb4c6cd57c08fa65d717f3bb4eb34e75",
-				"fake-instance-5": "065401a6-c9a3-2b2e-2894-9ec4a562066d2c54a68a67fcc7824f6903a8b6f01366",
+				"fake-instance-1": "23525d72-bd78-5a0e-283b-cca10567e5c0",
+				"fake-instance-2": "31dc65f7-0792-446a-024b-6b6fe613f99f",
+				"fake-instance-3": "285c7aac-ff1f-54ea-94ae-10e28f191b5a",
+				"fake-instance-4": "e2b68b0d-3f8c-7a7f-facc-493f8dd1353f",
+				"fake-instance-5": "065401a6-c9a3-2b2e-2894-9ec4a562066d",
 			}
 
 			for name, guid := range expectedSuccesses {

--- a/internal/fakecapi/ids.go
+++ b/internal/fakecapi/ids.go
@@ -17,5 +17,5 @@ func stableGUID(s string) string {
 	h := sha256.New()
 	h.Write([]byte(s))
 	b := h.Sum(nil)
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }


### PR DESCRIPTION
Due to a bug in the GUID generation, we were using unusually long
GUIDs in tests. This change updates them to the standard length.