### PR TITLE
feat: -ignore-instance-errors flag

### DIFF
--- a/integrationtests/check_deactivated_plans_test.go
+++ b/integrationtests/check_deactivated_plans_test.go
@@ -83,7 +83,7 @@ Number of service instances associated with deactivated plans: 2
 
 	It("shows instances belonging to deactivated plans in JSON", func() {
 		session := cf("upgrade-all-services", brokerName, "-check-deactivated-plans", "-json")
-		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
 		Expect(string(session.Out.Contents())).To(MatchJSON(`
   [
     {
@@ -134,5 +134,10 @@ Number of service instances associated with deactivated plans: 2
     }
   ]
 `))
+	})
+
+	It("respects the -ignore-instance-errors flag", func() {
+		session := cf("upgrade-all-services", brokerName, "-check-deactivated-plans", "-ignore-instance-errors")
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
 	})
 })

--- a/integrationtests/check_up_to_date_test.go
+++ b/integrationtests/check_up_to_date_test.go
@@ -114,7 +114,7 @@ Number of service instances which failed to create: 1
 
 	It("prints deactivated plans, pending upgrades and failed creates in JSON", func() {
 		session := cf("upgrade-all-services", brokerName, "-check-up-to-date", "--json")
-		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
 		Expect(strings.TrimSpace(string(session.Out.Contents()))).To(MatchJSON(`
 {
   "plan_deactivated": [
@@ -217,5 +217,10 @@ Number of service instances which failed to create: 1
   ]
 }
 `))
+	})
+
+	It("respects the -ignore-instance-errors flag", func() {
+		session := cf("upgrade-all-services", brokerName, "-check-up-to-date", "-ignore-instance-errors")
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
 	})
 })

--- a/integrationtests/min_version_required_test.go
+++ b/integrationtests/min_version_required_test.go
@@ -111,7 +111,7 @@ No instances found with version lower than "1.2.0"
 	Context("JSON output", func() {
 		It("detects versions below the minimum", func() {
 			session := cf("upgrade-all-services", brokerName, "-min-version-required", "1.2.3", "--json")
-			Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
+			Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
 			Expect(session.Out.Contents()).To(MatchJSON(`
 [
     {
@@ -189,7 +189,7 @@ No instances found with version lower than "1.2.0"
 
 		It("ignores versions at or above the minimum", func() {
 			session := cf("upgrade-all-services", brokerName, "-min-version-required", "1.2.2", "--json")
-			Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
+			Eventually(session).WithTimeout(time.Minute).Should(Exit(1))
 			Expect(session.Out.Contents()).To(MatchJSON(`
   [
     {
@@ -246,5 +246,10 @@ No instances found with version lower than "1.2.0"
 			Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
 			Expect(string(session.Out.Contents())).To(MatchJSON(`[]`))
 		})
+	})
+
+	It("respects the -ignore-instance-errors flag", func() {
+		session := cf("upgrade-all-services", brokerName, "-min-version-required", "1.2.3", "-ignore-instance-errors")
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(0))
 	})
 })

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,18 +15,19 @@ import (
 // error rather than a user error, and you have to cast the `uint` to compare to a `len()`,
 // which just looks more complicated than it has to. So we use an `int` for pragmatic reasons.
 type Config struct {
-	Action            Action
-	BrokerName        string
-	APIToken          string
-	APIEndpoint       string
-	SkipSSLValidation bool
-	HTTPLogging       bool
-	JSONOutput        bool
-	MinVersion        *version.Version
-	ParallelUpgrades  int
-	Limit             int
-	Attempts          int
-	RetryInterval     time.Duration
+	Action               Action
+	BrokerName           string
+	APIToken             string
+	APIEndpoint          string
+	SkipSSLValidation    bool
+	HTTPLogging          bool
+	JSONOutput           bool
+	MinVersion           *version.Version
+	ParallelUpgrades     int
+	Limit                int
+	Attempts             int
+	RetryInterval        time.Duration
+	IgnoreInstanceErrors bool
 }
 
 // ParseConfig combines and validates data from the command line and CLIConnection object
@@ -50,6 +51,7 @@ func ParseConfig(conn CLIConnection, args []string) (Config, error) {
 	flagSet.IntVar(&cfg.Limit, limitFlag, limitDefault, limitDescription)
 	flagSet.IntVar(&cfg.Attempts, attemptsFlag, attemptsDefault, attemptsDescription)
 	flagSet.DurationVar(&cfg.RetryInterval, retryIntervalFlag, retryIntervalDefault, retryIntervalDescription)
+	flagSet.BoolVar(&cfg.IgnoreInstanceErrors, ignoreInstanceErrorsFlag, ignoreInstanceErrorsDefault, ignoreInstanceErrorsDescription)
 
 	// This ranges over a chain of functions, each of which performs a single action and may return an error.
 	// The chain breaks at the first error received. It arguably reads better than repetitive error handling logic.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -49,4 +49,8 @@ const (
 	retryIntervalFlag        = "retry-interval"
 	retryIntervalDescription = "time to wait after a failure before a retry, e.g. '10s', '2m'. Maximum 10m, default 0."
 	retryIntervalMaximum     = 10 * time.Minute
+
+	ignoreInstanceErrorsDefault     = false
+	ignoreInstanceErrorsFlag        = "ignore-instance-errors"
+	ignoreInstanceErrorsDescription = "exit with code 0 even when the -min-version-required, -check-deactivated-plans, or -check-up-to-date detect outdated service instances"
 )

--- a/internal/upgrader/check_up_to_date.go
+++ b/internal/upgrader/check_up_to_date.go
@@ -2,7 +2,6 @@ package upgrader
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"upgrade-all-services-cli-plugin/internal/ccapi"
 	"upgrade-all-services-cli-plugin/internal/slicex"
@@ -43,7 +42,7 @@ func outputUpToDateText(instancesWithDeactivatedPlans, upgradableInstances, crea
 	logServiceInstances(createFailedInstances)
 
 	if len(instancesWithDeactivatedPlans) > 0 || len(upgradableInstances) > 0 {
-		return errors.New("discovered service instances associated with deactivated plans or with an upgrade available")
+		return newInstanceError("discovered service instances associated with deactivated plans or with an upgrade available")
 	}
 
 	fmt.Println("No instances found associated with deactivated plans or with an upgrade available")
@@ -70,7 +69,9 @@ func outputUpToDateJSON(instancesWithDeactivatedPlans, upgradableInstances, crea
 
 	fmt.Println(string(output))
 
-	// In contrast to text output, we don't exit with an error code. The rationale is that JSON may be piped
-	// to a processor command like `jq`, and a command failure would be more of a hindrance than a help.
+	if len(instancesWithDeactivatedPlans) > 0 || len(upgradableInstances) > 0 {
+		return newInstanceError("discovered service instances associated with deactivated plans or with an upgrade available")
+	}
+
 	return nil
 }

--- a/internal/upgrader/deactivated_plans.go
+++ b/internal/upgrader/deactivated_plans.go
@@ -2,7 +2,6 @@ package upgrader
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"upgrade-all-services-cli-plugin/internal/ccapi"
 	"upgrade-all-services-cli-plugin/internal/slicex"
@@ -36,18 +35,20 @@ func outputDeactivatedPlansText(instancesWithDeactivatedPlans []ccapi.ServiceIns
 	fmt.Printf("Number of service instances associated with deactivated plans: %d\n", len(instancesWithDeactivatedPlans))
 	fmt.Println()
 	logServiceInstances(instancesWithDeactivatedPlans)
-	return errors.New("discovered deactivated plans associated with instances")
+	return newInstanceError("discovered deactivated plans associated with instances")
 }
 
-func outputDeactivatedPlansJSON(instances []ccapi.ServiceInstance) error {
-	output, err := json.MarshalIndent(slicex.Map(instances, newJSONOutputServiceInstance), "", "  ")
+func outputDeactivatedPlansJSON(instancesWithDeactivatedPlans []ccapi.ServiceInstance) error {
+	output, err := json.MarshalIndent(slicex.Map(instancesWithDeactivatedPlans, newJSONOutputServiceInstance), "", "  ")
 	if err != nil {
 		return err
 	}
 
 	fmt.Println(string(output))
 
-	// In contrast to text output, we don't exit with an error code. The rationale is that JSON may be piped
-	// to a processor command like `jq`, and a command failure would be more of a hindrance than a help.
+	if len(instancesWithDeactivatedPlans) > 0 {
+		return newInstanceError("discovered deactivated plans associated with instances")
+	}
+
 	return nil
 }

--- a/internal/upgrader/instanceerror.go
+++ b/internal/upgrader/instanceerror.go
@@ -1,0 +1,19 @@
+package upgrader
+
+import "fmt"
+
+func newInstanceError(message string) error {
+	return InstanceError{message: message}
+}
+
+func newInstanceErrorf(format string, args ...any) error {
+	return InstanceError{message: fmt.Sprintf(format, args...)}
+}
+
+type InstanceError struct {
+	message string
+}
+
+func (e InstanceError) Error() string {
+	return e.message
+}

--- a/internal/upgrader/min_version_required.go
+++ b/internal/upgrader/min_version_required.go
@@ -41,7 +41,7 @@ func outputMinimumVersionText(filteredInstances []ccapi.ServiceInstance, totalSe
 	fmt.Printf("Number of service instances with a version lower than %q: %d\n", minVersion, len(filteredInstances))
 	fmt.Println()
 	logServiceInstances(filteredInstances)
-	return fmt.Errorf("found %d service instances with a version less than the minimum required", len(filteredInstances))
+	return newInstanceErrorf("found %d service instances with a version less than the minimum required", len(filteredInstances))
 }
 
 func outputMinimumVersionJSON(filteredInstances []ccapi.ServiceInstance) error {
@@ -54,8 +54,10 @@ func outputMinimumVersionJSON(filteredInstances []ccapi.ServiceInstance) error {
 
 	fmt.Println(string(output))
 
-	// In contrast to text output, we don't exit with an error code. The rationale is that JSON may be piped
-	// to a processor command like `jq`, and a command failure would be more of a hindrance than a help.
+	if len(filteredInstances) > 0 {
+		return newInstanceErrorf("found %d service instances with a version less than the minimum required", len(filteredInstances))
+	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"upgrade-all-services-cli-plugin/internal/config"
 
@@ -18,10 +17,8 @@ type UpgradePlugin struct{}
 // It is the entry point for running the plugin.
 func (p *UpgradePlugin) Run(cliConnection plugin.CliConnection, args []string) {
 	if args[0] == "upgrade-all-services" {
-		if err := upgradeAllServices(cliConnection, args[1:]); err != nil {
-			fmt.Fprintf(os.Stderr, "upgrade-all-services plugin failed: %s", err.Error())
-			os.Exit(1)
-		}
+		exitCode := upgradeAllServices(cliConnection, args[1:])
+		os.Exit(exitCode)
 	}
 }
 

--- a/upgrade_all.go
+++ b/upgrade_all.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"time"
 
 	"upgrade-all-services-cli-plugin/internal/ccapi"
@@ -12,15 +15,22 @@ import (
 	"code.cloudfoundry.org/cli/plugin"
 )
 
+// The CF CLI doesn't maintain exit codes, so we can't pass on any information with them
+const (
+	exitSuccess = 0
+	exitError   = 1
+)
+
 // upgradeAllServices is a coordination layer that connects the different pieces of this plugin together,
 // while delegating the actual work to other packages. Principally it:
 // - reads the endpoint and credentials for connecting to CF
 // - reads and parses the command line arguments
 // - requests the start of the upgrade process with the required data
-func upgradeAllServices(cliConnection plugin.CliConnection, args []string) error {
+func upgradeAllServices(cliConnection plugin.CliConnection, args []string) int {
 	cfg, err := config.ParseConfig(cliConnection, args)
 	if err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "upgrade-all-services plugin failed: %s", err)
+		return exitError
 	}
 
 	logr := logger.New(time.Minute)
@@ -29,7 +39,7 @@ func upgradeAllServices(cliConnection plugin.CliConnection, args []string) error
 		reqr.Logger = logr
 	}
 
-	return upgrader.Upgrade(ccapi.NewCCAPI(reqr), logr, upgrader.UpgradeConfig{
+	err = upgrader.Upgrade(ccapi.NewCCAPI(reqr), logr, upgrader.UpgradeConfig{
 		BrokerName:       cfg.BrokerName,
 		ParallelUpgrades: cfg.ParallelUpgrades,
 		Action:           cfg.Action,
@@ -39,4 +49,20 @@ func upgradeAllServices(cliConnection plugin.CliConnection, args []string) error
 		Attempts:         cfg.Attempts,
 		RetryInterval:    cfg.RetryInterval,
 	})
+
+	isInstanceError := errors.As(err, &upgrader.InstanceError{})
+
+	switch {
+	case err == nil, isInstanceError && cfg.IgnoreInstanceErrors:
+		return exitSuccess
+	case isInstanceError && cfg.JSONOutput:
+		// We don't pollute the JSON with an error message in case STDOUT and STDERR streams are merged
+		return exitError
+	case isInstanceError:
+		fmt.Fprintf(os.Stderr, "upgrade-all-services plugin failed: %s", err)
+		return exitError
+	default:
+		fmt.Fprintf(os.Stderr, "upgrade-all-services plugin error: %s", err)
+		return exitError
+	}
 }


### PR DESCRIPTION
The actions -check-deactivated-plans, -check-up-to-date and -min-version-required
will exit with a non-zero code if they find matching service instances. When the
-json flag was added, behavior was changed so that the exit code would always be
zero when using JSON output. The idea was that you might want to pipe the JSON
output to `jq` or a similar processor, and having a failure might not be helpful.
But it was pointed out that you might want to do this with text output too, and
having a change of exit code implicit in the -json flag could be unexpected.
Hence the new -ignore-instance-errors which allows you to control whether finding
instances will result in a non-zero exit code.